### PR TITLE
fix: bug where all compiled source files would have the same source ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dmypy.json
 
 # setuptools-scm
 version.py
+
+# Ape stuff
+.build/

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 import solcx  # type: ignore
-from ape.api import ConfigItem, ConfigDict
 from ape.api.compiler import CompilerAPI
 from ape.types import ABI, Bytecode, ContractType
 from ape.utils import cached_property

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import List, Optional, Set
 
 import solcx  # type: ignore
+from ape.api import ConfigItem, ConfigDict
 from ape.api.compiler import CompilerAPI
 from ape.types import ABI, Bytecode, ContractType
 from ape.utils import cached_property
@@ -60,6 +61,7 @@ class SolidityCompiler(CompilerAPI):
         # todo: move this to solcx
         contract_types = []
         files = []
+        solc_version = None
         for path in contract_filepaths:
             files.append(path)
             source = path.read_text()
@@ -88,11 +90,13 @@ class SolidityCompiler(CompilerAPI):
             solc_version=solc_version,
         )
         for contract_name, contract_type in output.items():
-            contract_name = contract_name.split(":")[-1]
+            contract_id_parts = contract_name.split(":")
+            contract_path = contract_id_parts[0]
+            contract_name = contract_id_parts[-1]
             contract_types.append(
                 ContractType(
                     contractName=contract_name,
-                    sourceId=str(path),
+                    sourceId=contract_path,
                     deploymentBytecode=Bytecode(bytecode=contract_type["bin"]),  # type: ignore
                     runtimeBytecode=Bytecode(bytecode=contract_type["bin-runtime"]),  # type: ignore
                     abi=[ABI.from_dict(abi) for abi in contract_type["abi"]],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import shutil
 
 import pytest  # type: ignore
 from ape import Project
@@ -6,4 +7,9 @@ from ape import Project
 
 @pytest.fixture
 def project():
-    return Project(Path(__file__).parent)
+    try:
+        project = Project(Path(__file__).parent)
+        shutil.rmtree(project._cache_folder)
+        yield project
+    finally:
+        shutil.rmtree(project._cache_folder)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import shutil
+from pathlib import Path
 
 import pytest  # type: ignore
 from ape import Project

--- a/tests/contracts/solcontract_2.sol
+++ b/tests/contracts/solcontract_2.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+contract solcontract_2 {
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,2 +1,10 @@
+from pathlib import Path
+
+TEST_PROJECTS = [str(p.stem) for p in (Path(__file__).parent / "contracts").iterdir()]
+
+
 def test_integration(project):
-    assert "solcontract" in project.contracts
+    for proj in TEST_PROJECTS:
+        assert proj in project.contracts
+        contract = project.contracts[proj]
+        assert contract.sourceId == f"contracts/{proj}.sol"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,10 +1,10 @@
 from pathlib import Path
 
-TEST_PROJECTS = [str(p.stem) for p in (Path(__file__).parent / "contracts").iterdir()]
+TEST_CONTRACTS = [str(p.stem) for p in (Path(__file__).parent / "contracts").iterdir()]
 
 
 def test_integration(project):
-    for proj in TEST_PROJECTS:
-        assert proj in project.contracts
-        contract = project.contracts[proj]
-        assert f"contracts/{proj}.sol" in contract.sourceId
+    for contract in TEST_CONTRACTS:
+        assert contract in project.contracts
+        contract = project.contracts[contract]
+        assert f"contracts/{contract}.sol" in contract.sourceId

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,4 +7,4 @@ def test_integration(project):
     for proj in TEST_PROJECTS:
         assert proj in project.contracts
         contract = project.contracts[proj]
-        assert contract.sourceId == f"contracts/{proj}.sol"
+        assert f"contracts/{proj}.sol" in contract.sourceId

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -7,4 +7,4 @@ def test_integration(project):
     for contract in TEST_CONTRACTS:
         assert contract in project.contracts
         contract = project.contracts[contract]
-        assert f"contracts/{contract}.sol" in contract.sourceId
+        assert f"contracts/{contract.contractName}.sol" in contract.sourceId


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #15 

The source ID is always the same! This violates EIP-2678 and is a bug. It is supposed to be extracted in each iteration of the for-loop.

### How I did it

Use the looped variable path to determine source id rather some variable that just happens to be defined.

### How to verify it

ape compile

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
