### PR TITLE
feat: allow configuring import re-mappings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ dmypy.json
 
 # setuptools-scm
 version.py
+
+# Ape stuff
+.build/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,34 @@ ape compile
 
 The byte-code and ABI for your contracts should now exist in a `__local__.json` file in a `.build/` directory.
 
+### Dependency Mapping
+
+To configure import remapping, use your project's `ape-config.yaml` file:
+
+```yaml
+solidity:
+  import_remapping:
+    - "@openzeppelin=path/to/open_zeppelin/contracts"
+```
+
+If you are using the `dependencies:` key in your `ape-config.yaml`, `ape` can automatically
+search those dependencies for the path.
+
+```yaml
+dependencies:
+  open_zeppelin: OpenZeppelin/openzeppelin-contracts@4.4.0
+
+solidity:
+  import_remapping:
+    - "@openzeppelin=open_zeppelin/contracts"
+```
+
+Once you have your dependencies configured, you can import packages using your import keys:
+
+```solidity
+import "@openzeppelin/token/ERC721/ERC721.sol";
+```
+
 ## Development
 
 This project is in early development and should be considered an alpha.

--- a/ape_solidity/__init__.py
+++ b/ape_solidity/__init__.py
@@ -1,6 +1,11 @@
 from ape import plugins
 
-from .compiler import SolidityCompiler
+from .compiler import SolidityCompiler, SolidityConfig
+
+
+@plugins.register(plugins.Config)
+def config_class():
+    return SolidityConfig
 
 
 @plugins.register(plugins.CompilerPlugin)

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -33,6 +33,8 @@ def get_pragma_spec(source: str) -> Optional[NpmSpec]:
 
 
 class SolidityConfig(ConfigItem):
+    # Configure re-mappings using a `=` separated-str,
+    # e.g. '@import_name=path/to/dependency'
     import_remapping: List[str] = []
 
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -86,7 +86,7 @@ class SolidityCompiler(CompilerAPI):
     @property
     def import_remapping(self) -> Dict[str, str]:
         """
-        Specify the import remapping either from a ``=`` separated str or a dictionary.
+        Specify the import remapping either from a ``=`` separated str.
         """
         items = self.config.import_remapping
         import_map = {}

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -92,7 +92,7 @@ class SolidityCompiler(CompilerAPI):
         e.g. ``'@import_name=path/to/dependency'``.
         """
         items = self.config.import_remapping
-        import_map = {}
+        import_map: Dict[str, str] = {}
 
         if not items:
             return import_map

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -88,7 +88,8 @@ class SolidityCompiler(CompilerAPI):
     @property
     def import_remapping(self) -> Dict[str, str]:
         """
-        Specify the import remapping either from a ``=`` separated str.
+        Specify the remapping using a ``=`` separated str
+        e.g. ``'@import_name=path/to/dependency'``.
         """
         items = self.config.import_remapping
         import_map = {}

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -3,8 +3,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 import solcx  # type: ignore
-from ape.api import ConfigItem
-from ape.api.compiler import CompilerAPI
+from ape.api import CompilerAPI, ConfigItem
 from ape.exceptions import CompilerError, ConfigError
 from ape.types import ABI, Bytecode, ContractType
 from ape.utils import cached_property

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
         "py-solc-x>=1.1.0,<1.2.0",
-        "eth-ape>=0.1.0a30",
+        "eth-ape>=0.1.0a31",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
         "py-solc-x>=1.1.0,<1.2.0",
-        "eth-ape>=0.1.0a29",
+        "eth-ape>=0.1.0a30",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #14 

Requires https://github.com/ApeWorX/ape/pull/284 (required to use, not required to install)

### How I did it

Use `import_remappings` kwarg on `solcx` compiler call.
Create the `Dict` of the mappings beforehand using the config item.
If the path does not exist in the config, try appending the `.ape/packages` path to it - if it then exists, use that path.. This is a way to enable a shortcut of using `dependecies:`

### How to verify it

https://github.com/ApeWorX/simple-nft/pull/1

^ this compiles

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
