### PR TITLE
fix: broken parsing of ContractType

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -163,6 +163,8 @@ class SolidityCompiler(CompilerAPI):
             )
             contract_type["deploymentBytecode"] = {"bytecode": contract_type["bin"]}
             contract_type["runtimeBytecode"] = {"bytecode": contract_type["bin-runtime"]}
+            contract_type["userdoc"] = load_dict(contract_type["userdoc"])
+            contract_type["devdoc"] = load_dict(contract_type["devdoc"])
 
             contract_types.append(ContractType.parse_obj(contract_type))
 


### PR DESCRIPTION
### What I did
```
userdoc
  value is not a valid dict (type=type_error.dict)
devdoc
  value is not a valid dict (type=type_error.dict)
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
