### PR TITLE
fix: put back ABI serializaiton

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -8,6 +8,7 @@ from ape.api import CompilerAPI, ConfigItem
 from ape.exceptions import CompilerError, ConfigError
 from ape.types import ContractType
 from ape.utils import cached_property, get_relative_path
+from ethpm_types.abi import ConstructorABI, EventABI, FallbackABI, MethodABI
 from semantic_version import NpmSpec, Version  # type: ignore
 
 
@@ -161,6 +162,18 @@ class SolidityCompiler(CompilerAPI):
                 if base_path and contract_path.is_absolute()
                 else str(contract_path)
             )
+            parsed_abis = []
+            for abi in contract_type["abi"]:
+                if abi["type"] == "event":
+                    parsed_abis.append(EventABI.parse_obj(abi))
+                elif abi["type"] == "fallback":
+                    parsed_abis.append(FallbackABI.parse_obj(abi))
+                elif abi["type"] == "method":
+                    parsed_abis.append(MethodABI.parse_obj(abi))
+                elif abi["type"] == "constructor":
+                    parsed_abis.append(ConstructorABI.parse_obj(abi))
+
+            contract_type["abi"] = parsed_abis
             contract_type["deploymentBytecode"] = {"bytecode": contract_type["bin"]}
             contract_type["runtimeBytecode"] = {"bytecode": contract_type["bin-runtime"]}
             contract_type["userdoc"] = load_dict(contract_type["userdoc"])

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(
         "importlib-metadata ; python_version<'3.8'",
         "py-solc-x>=1.1.0,<1.2.0",
         "eth-ape>=0.1.0b4",
+        "ethpm-types>=0.1.0b6"
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

I am not sure if I am doing this right, as per the new changes, but this needs to be an ABI type from `ethpm-types`, not a raw dictionary, or else problems down the line occur.

Before, we were doing `[ABI(**abi) for abi in contract_type["abi"]`. You can see it got deleted in some of the more recent commits that upgraded `ethpm-types` related stuff.  We are unable to use that syntax now because `ABI` is a `Union` types and has no `parse_obj()` method or anything.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
