### PR TITLE
fix: bug preventing compiling multiple versions

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -241,7 +241,8 @@ class SolidityCompiler(CompilerAPI):
                 contract_name = contract_id_parts[-1]
 
                 if contract_name not in input_contract_names:
-                    # Contract was compiled already in a later compiler version.
+                    # Contract was either not specified or was compiled
+                    # previously from a later-solidity version.
                     continue
 
                 contract_path = Path(contract_id_parts[0])

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -164,8 +164,8 @@ class SolidityCompiler(CompilerAPI):
     ) -> List[ContractType]:
         # TODO: move this to solcx
         contract_types: List[ContractType] = []
-        files_by_solc_version: Dict[str, Set[Path]] = {}
-        solc_version_by_file_name: Dict[str, str] = {}
+        files_by_solc_version: Dict[Version, Set[Path]] = {}
+        solc_version_by_file_name: Dict[Version, Path] = {}
 
         for path in contract_filepaths:
             source = path.read_text()
@@ -189,7 +189,7 @@ class SolidityCompiler(CompilerAPI):
             if solc_version not in files_by_solc_version:
                 files_by_solc_version[solc_version] = set()
 
-            version_meeting_same_file = solc_version_by_file_name.get(path.name)
+            version_meeting_same_file = solc_version_by_file_name.get(path)
             if version_meeting_same_file:
                 if solc_version > version_meeting_same_file:
                     # Compile file using lateset version it can.
@@ -202,7 +202,7 @@ class SolidityCompiler(CompilerAPI):
                 # else: do nothing
             else:
                 files_by_solc_version[solc_version].add(path)
-                solc_version_by_file_name[path.name] = solc_version
+                solc_version_by_file_name[path] = solc_version
 
         if not base_path:
             base_path = self.config_manager.contracts_folder

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -235,11 +235,12 @@ class SolidityCompiler(CompilerAPI):
             def load_dict(data: Union[str, dict]) -> Dict:
                 return data if isinstance(data, dict) else json.loads(data)
 
+            input_contract_names = [f.name for f in files]
             for contract_name, contract_type in output.items():
                 contract_id_parts = contract_name.split(":")
                 contract_name = contract_id_parts[-1]
 
-                if contract_name not in [f.name for f in files]:
+                if contract_name not in input_contract_names:
                     # Contract was compiled already in a later compiler version.
                     continue
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -89,7 +89,7 @@ class SolidityCompiler(CompilerAPI):
         items = self.config.import_remapping
         import_map: Dict[str, str] = {}
         contracts_cache = base_path / ".cache" if base_path else Path(".cache")
-        packages_cache = Path.home() / ".ape" / "packages"
+        packages_cache = self.config_manager.packages_folder
 
         if not items:
             return import_map

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -239,7 +239,7 @@ class SolidityCompiler(CompilerAPI):
                 contract_id_parts = contract_name.split(":")
                 contract_name = contract_id_parts[-1]
 
-                if contract_name in [c.name for c in contract_types]:
+                if contract_name not in [f.name for f in files]:
                     # Contract was compiled already in a later compiler version.
                     continue
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -235,7 +235,7 @@ class SolidityCompiler(CompilerAPI):
             def load_dict(data: Union[str, dict]) -> Dict:
                 return data if isinstance(data, dict) else json.loads(data)
 
-            input_contract_names = [f.name for f in files]
+            input_contract_names = [f.stem for f in files]
             for contract_name, contract_type in output.items():
                 contract_id_parts = contract_name.split(":")
                 contract_name = contract_id_parts[-1]

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -176,7 +176,9 @@ class SolidityCompiler(CompilerAPI):
                     if solc_version:
                         solcx.install_solc(solc_version, show_progress=False)
                     else:
-                        raise CompilerError(f"Solidity version '{solc_version}' is not available.")
+                        raise CompilerError(
+                            f"Solidity version specification '{pragma_spec}' could not be met."
+                        )
                 else:
                     solc_version = pragma_spec.select(self.installed_versions)
             else:

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,8 @@ setup(
         "importlib-metadata ; python_version<'3.8'",
         "py-solc-x>=1.1.0,<1.2.0",
         "eth-ape>=0.2.1,<0.3.0",
-        "ethpm-types>=0.1.1,<0.2.0",
+        "ethpm-types>=0.1.1,<0.3.0",
         "packaging>=20.9,<21",
-        "ethpm-types>=0.1.0b6",
     ],  # NOTE: Add 3rd party libraries here
     python_requires=">=3.7.2,<4",
     extras_require=extras_require,

--- a/tests/contracts/CompilesOnce.sol
+++ b/tests/contracts/CompilesOnce.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+contract FixBugWhereCompiledTwice {
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/contracts/CompilesOnce.sol
+++ b/tests/contracts/CompilesOnce.sol
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.0;
+pragma solidity >=0.8.0;
 
-contract FixBugWhereCompiledTwice {
+contract CompilesOnce {
+    // This contract tests the scenario when we have a contract with
+    // a similar compiler version to more than one other contract's.
+    // This ensures we don't compile the same contract more than once.
+
     function foo() pure public returns(bool) {
         return true;
     }

--- a/tests/contracts/OlderVersion.sol
+++ b/tests/contracts/OlderVersion.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity =0.5.16;
+
+contract OlderVersion {
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/contracts/Solcontract.sol
+++ b/tests/contracts/Solcontract.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.4;
 
 import "@remapping/Dependency.sol";
 import "@remapping_2/Dependency.sol";
+import "CompilesOnce.sol";
 
 contract Solcontract {
     function foo() pure public returns(bool) {

--- a/tests/contracts/Solcontract_2.sol
+++ b/tests/contracts/Solcontract_2.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.8.4;
+pragma solidity =0.8.12;
+
+import "CompilesOnce.sol";
 
 contract Solcontract_2 {
     function foo() pure public returns(bool) {

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
+import pytest
+
 TEST_CONTRACTS = [
     str(p.stem) for p in (Path(__file__).parent / "contracts").iterdir() if ".cache" not in str(p)
 ]
 
 
-def test_integration(project):
-    for contract in TEST_CONTRACTS:
-        assert contract in project.contracts
-        contract = project.contracts[contract]
-        assert contract.source_id == f"{contract.name}.sol"
+@pytest.mark.parametrize("contract", TEST_CONTRACTS)
+def test_integration(project, contract):
+    assert contract in project.contracts
+    contract = project.contracts[contract]
+    assert contract.source_id == f"{contract.name}.sol"


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #27 

### How I did it

Create a mapping of version to files before running through the  solcx

### How to verify it

Compile projects that use multiple Solidity versions.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
