### PR TITLE
fix: bug preventing compiling contracts with different type than file name

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -2,7 +2,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Union, cast
+from typing import Dict, List, Optional, Set, Tuple, Union, cast
 
 import solcx  # type: ignore
 from ape.api import CompilerAPI, PluginConfig
@@ -232,20 +232,31 @@ class SolidityCompiler(CompilerAPI):
 
             output = solcx.compile_files(files, **kwargs)
 
+            def parse_contract_name(value: str) -> Tuple[Path, str]:
+                parts = value.split(":")
+                return Path(parts[0]), parts[1]
+
+            # Filter source files that the user did not ask for, such as
+            # imported relative files that are not part of the input.
+            input_contract_names: List[str] = []
+            for contract_id in output.keys():
+                path, name = parse_contract_name(contract_id)
+                for input_file_path in files:
+                    if str(path) in str(input_file_path):
+                        input_contract_names.append(name)
+
             def load_dict(data: Union[str, dict]) -> Dict:
                 return data if isinstance(data, dict) else json.loads(data)
 
-            input_contract_names = [f.stem for f in files]
             for contract_name, contract_type in output.items():
-                contract_id_parts = contract_name.split(":")
-                contract_name = contract_id_parts[-1]
+                contract_path, contract_name = parse_contract_name(contract_name)
 
                 if contract_name not in input_contract_names:
                     # Contract was either not specified or was compiled
                     # previously from a later-solidity version.
                     continue
 
-                contract_path = Path(contract_id_parts[0])
+                contract_path = Path(contract_path)
                 contract_type["contractName"] = contract_name
                 contract_type["sourceId"] = (
                     str(get_relative_path(base_path / contract_path, base_path))

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -256,7 +256,6 @@ class SolidityCompiler(CompilerAPI):
                     # previously from a later-solidity version.
                     continue
 
-                contract_path = Path(contract_path)
                 contract_type["contractName"] = contract_name
                 contract_type["sourceId"] = (
                     str(get_relative_path(base_path / contract_path, base_path))

--- a/tests/contracts/DifferentNameThanFile.sol
+++ b/tests/contracts/DifferentNameThanFile.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.4.0;
+
+contract ApeDifferentNameThanFile {
+    function ContractWithDifferentNameThanFile(){
+
+    }
+}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,13 +2,20 @@ from pathlib import Path
 
 import pytest
 
-TEST_CONTRACTS = [
-    str(p.stem) for p in (Path(__file__).parent / "contracts").iterdir() if ".cache" not in str(p)
-]
+BASE_PATH = Path(__file__).parent / "contracts"
+TEST_CONTRACTS = [str(p.stem) for p in BASE_PATH.iterdir() if ".cache" not in str(p)]
 
 
-@pytest.mark.parametrize("contract", TEST_CONTRACTS)
+@pytest.mark.parametrize(
+    "contract", [c for c in TEST_CONTRACTS if "DifferentNameThanFile" not in str(c)]
+)
 def test_integration(project, contract):
     assert contract in project.contracts
     contract = project.contracts[contract]
     assert contract.source_id == f"{contract.name}.sol"
+
+
+def test_compile_contract_with_different_name_than_file(project):
+    file_name = "DifferentNameThanFile.sol"
+    contract = project.contracts["ApeDifferentNameThanFile"]
+    assert contract.source_id == file_name


### PR DESCRIPTION
### What I did

Regression preventing me from compiling `ds-test` repo.

### How I did it

Smarter, more complex check to findout if input contract types match output

### How to verify it

See test!
Also compile the `ds-test` repo or use it as a dependency:

```yaml
dependencies:
  - name: ds-test
    github: dapphub/ds-test
    branch: master
    contracts_folder: src
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
