### PR TITLE
fix: ape compile source import references

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -156,12 +156,16 @@ class SolidityCompiler(CompilerAPI):
                         f"where 'version_id' is one of '{options_str}'."
                     )
 
+            # Re-build a downloaded dependency manifest into the .cache directory for imports.
             sub_contracts_cache = contracts_cache / suffix
             if not sub_contracts_cache.exists() or not list(sub_contracts_cache.iterdir()):
                 cached_manifest_file = data_folder_cache / f"{name}.json"
                 if not cached_manifest_file.exists():
-                    # Dependency should have gotten installed prior to this.
-                    raise CompilerError(f"Missing dependency '{suffix}'.")
+                    # Attempt to load dependencies.
+                    _ = self.project_manager.dependencies
+
+                    if not cached_manifest_file.exists():
+                        raise CompilerError(f"Unable to find dependency '{suffix}'.")
 
                 manifest_dict = json.loads(cached_manifest_file.read_text())
                 manifest = PackageManifest(**manifest_dict)

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -271,7 +271,7 @@ class SolidityCompiler(CompilerAPI):
 
         return contract_types
 
-    def fetch_imports(
+    def get_imports(
         self, contract_filepaths: List[Path], base_path: Optional[Path]
     ) -> Dict[str, List[str]]:
         def import_str_to_paths(path: str, contract_filenames) -> List[str]:

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -90,17 +90,17 @@ class SolidityCompiler(CompilerAPI):
         e.g. ``'@import_name=path/to/dependency'``.
         """
         import_map: Dict[str, str] = {}
-        check_items = self.config.import_remapping
+        items = self.config.import_remapping
 
-        if not check_items:
+        if not items:
             return import_map
 
-        if not isinstance(check_items, (list, tuple)) or not isinstance(check_items[0], str):
+        if not isinstance(items, (list, tuple)) or not isinstance(items[0], str):
             raise IncorrectMappingFormatError()
 
         # Convert to tuple for hashing, check if there's been a change
-        items = tuple(check_items)
-        if self._import_remapping_hash == hash(items):
+        items_tuple = tuple(items)
+        if self._import_remapping_hash == hash(items_tuple):
             return self._cached_import_map
 
         contracts_cache = base_path / ".cache" if base_path else Path(".cache")
@@ -168,7 +168,7 @@ class SolidityCompiler(CompilerAPI):
 
         # Update cache and hash
         self._cached_import_map = import_map
-        self._import_remapping_hash = hash(items)
+        self._import_remapping_hash = hash(items_tuple)
         return import_map
 
     def compile(

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -60,7 +60,7 @@ class SolidityCompiler(CompilerAPI):
     def name(self) -> str:
         return "solidity"
 
-    @cached_property
+    @property
     def config(self) -> SolidityConfig:
         return cast(SolidityConfig, self.config_manager.get_config(self.name))
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -52,7 +52,7 @@ class IncorrectMappingFormatError(ConfigError):
 
 
 class SolidityCompiler(CompilerAPI):
-    import_remapping_hash: Optional[int] = None
+    _import_remapping_hash: Optional[int] = None
     _cached_project_path: Optional[Path] = None
     _cached_import_map: Dict[str, str] = {}
 
@@ -104,9 +104,9 @@ class SolidityCompiler(CompilerAPI):
         if all(
             (
                 self._cached_project_path,
-                self.import_remapping_hash,
+                self._import_remapping_hash,
                 self._cached_project_path == self.project_manager.path,
-                self.import_remapping_hash == hash(items_tuple),
+                self._import_remapping_hash == hash(items_tuple),
             )
         ):
             return self._cached_import_map
@@ -177,7 +177,7 @@ class SolidityCompiler(CompilerAPI):
         # Update cache and hash
         self._cached_project_path = self.project_manager.path
         self._cached_import_map = import_map
-        self.import_remapping_hash = hash(items_tuple)
+        self._import_remapping_hash = hash(items_tuple)
         return import_map
 
     def compile(

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -89,7 +89,11 @@ class SolidityCompiler(CompilerAPI):
         Specify the remapping using a ``=`` separated str
         e.g. ``'@import_name=path/to/dependency'``.
         """
+        import_map: Dict[str, str] = {}
         check_items = self.config.import_remapping
+
+        if not check_items:
+            return import_map
 
         if not isinstance(check_items, (list, tuple)) or not isinstance(check_items[0], str):
             raise IncorrectMappingFormatError()
@@ -99,12 +103,8 @@ class SolidityCompiler(CompilerAPI):
         if self._import_remapping_hash == hash(items):
             return self._cached_import_map
 
-        import_map: Dict[str, str] = {}
         contracts_cache = base_path / ".cache" if base_path else Path(".cache")
         packages_cache = self.config_manager.packages_folder
-
-        if not items:
-            return import_map
 
         for item in items:
             item_parts = item.split("=")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 import shutil
 from pathlib import Path
 
+import ape
 import pytest  # type: ignore
-from ape import Project
 
 
 @pytest.fixture
 def project():
     base_project_dir = Path(__file__).parent
 
-    project = Project(base_project_dir)
+    project = ape.Project(base_project_dir)
     project.config_manager.PROJECT_FOLDER = base_project_dir
     project.config_manager.contracts_folder = base_project_dir / "contracts"
     try:
@@ -17,3 +17,13 @@ def project():
         yield project
     finally:
         shutil.rmtree(project._project._cache_folder)
+
+
+@pytest.fixture
+def compiler():
+    return ape.compilers.registered_compilers[".sol"]
+
+
+@pytest.fixture
+def config():
+    return ape.config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,24 +6,21 @@ import pytest  # type: ignore
 
 
 @pytest.fixture
-def project():
-    base_project_dir = Path(__file__).parent
+def config():
+    return ape.config
 
-    project = ape.Project(base_project_dir)
-    project.config_manager.PROJECT_FOLDER = base_project_dir
-    project.config_manager.contracts_folder = base_project_dir / "contracts"
-    try:
-        shutil.rmtree(project._project._cache_folder)
-        yield project
-    finally:
-        shutil.rmtree(project._project._cache_folder)
+
+@pytest.fixture
+def project(config):
+    base_project_dir = Path(__file__).parent
+    with config.using_project(base_project_dir) as project:
+        try:
+            shutil.rmtree(project._project._cache_folder)
+            yield project
+        finally:
+            shutil.rmtree(project._project._cache_folder)
 
 
 @pytest.fixture
 def compiler():
     return ape.compilers.registered_compilers[".sol"]
-
-
-@pytest.fixture
-def config():
-    return ape.config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,25 @@ import shutil
 from pathlib import Path
 
 import ape
-import pytest  # type: ignore
+import pytest
+
+DEPENDENCY_0_NAME = "__test_dependency__"
+DEPENDENCY_1_NAME = "__test_remapping__"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def clean_dependencies():
+    dep_1 = ape.config.packages_folder / DEPENDENCY_0_NAME
+    dep_2 = ape.config.packages_folder / DEPENDENCY_1_NAME
+
+    def _clean():
+        for _path in (dep_1, dep_2):
+            if _path.is_dir():
+                shutil.rmtree(_path)
+
+    _clean()
+    yield
+    _clean()
 
 
 @pytest.fixture
@@ -13,14 +31,20 @@ def config():
 @pytest.fixture
 def project(config):
     base_project_dir = Path(__file__).parent
+    contract_cache = base_project_dir / "contracts" / ".cache"
+    build_dir = base_project_dir / ".build"
+
+    def _clean():
+        for _path in (contract_cache, build_dir):
+            if _path.is_dir():
+                shutil.rmtree(str(_path))
+
+    _clean()
     with config.using_project(base_project_dir) as project:
-        try:
-            shutil.rmtree(project._project._cache_folder)
-            yield project
-        finally:
-            shutil.rmtree(project._project._cache_folder)
+        yield project
+        _clean()
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def compiler():
     return ape.compilers.registered_compilers[".sol"]

--- a/tests/contracts/CompilesOnce.sol
+++ b/tests/contracts/CompilesOnce.sol
@@ -2,6 +2,11 @@
 
 pragma solidity >=0.8.0;
 
+struct MyStruct {
+    string name;
+    uint value;
+}
+
 contract CompilesOnce {
     // This contract tests the scenario when we have a contract with
     // a similar compiler version to more than one other contract's.

--- a/tests/contracts/Imports.sol
+++ b/tests/contracts/Imports.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import * as Depend from "@remapping/Dependency.sol";
+import { MyStruct } from "CompilesOnce.sol";
+import "./folder/Relativecontract.sol";
+import "@remapping_2/Dependency.sol" as Depend2;
+
+contract Imports {
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/contracts/folder/Relativecontract.sol
+++ b/tests/contracts/folder/Relativecontract.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Relativecontract {
+
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/project/ape-config.yaml
+++ b/tests/project/ape-config.yaml
@@ -1,0 +1,7 @@
+dependencies:
+  - name: __test_remapping__
+    local: ../dependency
+
+solidity:
+  import_remapping:
+    - "@remapping=__test_remapping__"

--- a/tests/project/contracts/Contract.sol
+++ b/tests/project/contracts/Contract.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+import "@remapping/Dependency.sol";
+
+contract Contract {
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -15,7 +15,7 @@ EXPECTED_IMPORTS_SET = {
 @pytest.mark.parametrize(
     "contract", [c for c in TEST_CONTRACTS if "DifferentNameThanFile" not in str(c)]
 )
-def test_integration(project, contract):
+def test_compile(project, contract):
     assert contract in project.contracts
     contract = project.contracts[contract]
     assert contract.source_id == f"{contract.name}.sol"
@@ -35,7 +35,7 @@ def test_get_imports(project, compiler):
     # NOTE: returning a list
     assert type(contract_imports) == list
     # NOTE: in case order changes
-    assert EXPECTED_IMPORTS_SET == set(contract_imports)
+    assert set(contract_imports) == EXPECTED_IMPORTS_SET
 
 
 def test_get_import_remapping(compiler, project, config):

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,9 +42,9 @@ def test_get_import_remapping(compiler, project, config):
     import_remapping = compiler.get_import_remapping()
     assert import_remapping
 
-    with config.using_project(project.path / "project"):
+    with config.using_project(project.path / "project") as proj:
         # Trigger downloading dependencies in new project
-        dependencies = project.dependencies
+        dependencies = proj.dependencies
         assert dependencies
         # Should be different now that we have changed projects.
         second_import_remapping = compiler.get_import_remapping()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -43,8 +43,9 @@ def test_get_import_remapping(compiler, project, config):
     assert import_remapping
 
     with config.using_project(project.path / "project"):
-        # Doesn't auto-load dependendcies
-        _ = project.dependencies
+        # Trigger downloading dependencies in new project
+        dependencies = project.dependencies
+        assert dependencies
         # Should be different now that we have changed projects.
         second_import_remapping = compiler.get_import_remapping()
         assert second_import_remapping

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,7 +3,13 @@ from pathlib import Path
 import pytest
 
 BASE_PATH = Path(__file__).parent / "contracts"
-TEST_CONTRACTS = [str(p.stem) for p in BASE_PATH.iterdir() if ".cache" not in str(p)]
+TEST_CONTRACT_PATHS = [p for p in BASE_PATH.iterdir() if ".cache" not in str(p) and not p.is_dir()]
+TEST_CONTRACTS = [str(p.stem) for p in TEST_CONTRACT_PATHS]
+EXPECTED_IMPORTS_SET = {
+    "folder/Relativecontract.sol",
+    "CompilesOnce.sol",
+    ".cache/__test_dependency__/local/Dependency.sol",
+}
 
 
 @pytest.mark.parametrize(
@@ -19,3 +25,16 @@ def test_compile_contract_with_different_name_than_file(project):
     file_name = "DifferentNameThanFile.sol"
     contract = project.contracts["ApeDifferentNameThanFile"]
     assert contract.source_id == file_name
+
+
+def test_get_imports(project):
+    import_dict = project.compiler_manager.registered_compilers[".sol"].get_imports(
+        TEST_CONTRACT_PATHS, BASE_PATH
+    )
+    contract_imports = import_dict["Imports.sol"]
+    # NOTE: make sure there aren't duplicates
+    assert len([x for x in contract_imports if contract_imports.count(x) > 1]) == 0
+    # NOTE: returning a list
+    assert type(contract_imports) == list
+    # NOTE: in case order changes
+    assert EXPECTED_IMPORTS_SET == set(contract_imports)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,10 +27,8 @@ def test_compile_contract_with_different_name_than_file(project):
     assert contract.source_id == file_name
 
 
-def test_get_imports(project):
-    import_dict = project.compiler_manager.registered_compilers[".sol"].get_imports(
-        TEST_CONTRACT_PATHS, BASE_PATH
-    )
+def test_get_imports(project, compiler):
+    import_dict = compiler.get_imports(TEST_CONTRACT_PATHS, BASE_PATH)
     contract_imports = import_dict["Imports.sol"]
     # NOTE: make sure there aren't duplicates
     assert len([x for x in contract_imports if contract_imports.count(x) > 1]) == 0
@@ -38,3 +36,17 @@ def test_get_imports(project):
     assert type(contract_imports) == list
     # NOTE: in case order changes
     assert EXPECTED_IMPORTS_SET == set(contract_imports)
+
+
+def test_get_import_remapping(compiler, project, config):
+    import_remapping = compiler.get_import_remapping()
+    assert import_remapping
+
+    with config.using_project(project.path / "project"):
+        # Doesn't auto-load dependendcies
+        _ = project.dependencies
+        # Should be different now that we have changed projects.
+        second_import_remapping = compiler.get_import_remapping()
+        assert second_import_remapping
+
+    assert import_remapping != second_import_remapping


### PR DESCRIPTION
### What I did
Added logic for fetching referenced imports

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
partial fix for https://github.com/ApeWorX/ape/issues/623
unblocks @sabotagebeats https://github.com/ApeWorX/ape/issues/81

### How I did it
Read each source path and pull out imports
Add cleaned import strings to dictionary

### How to verify it
Ape core implementation https://github.com/ApeWorX/ape/pull/730
### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
