### PR TITLE
fix: issue causing unnecessary compilation

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -203,97 +203,9 @@ class SolidityCompiler(CompilerAPI):
         self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> List[ContractType]:
         contracts_path = base_path or self.config_manager.contracts_folder
-        imports = self.get_imports(get_all_files_in_directory(contracts_path), contracts_path)
-
-        def get_imported_source_paths(
-            path: Path, source_ids_checked: Optional[List[str]] = None
-        ) -> Set[Path]:
-            source_ids_checked = source_ids_checked or []
-            source_id = str(get_relative_path(path, contracts_path))
-            if source_id in source_ids_checked:
-                # Already got this source's imports
-                return set()
-
-            source_ids_checked.append(source_id)
-            import_paths = [contracts_path / i for i in imports.get(source_id, []) if i]
-            return_set = {i for i in import_paths}
-            for import_path in import_paths:
-                indirect_imports = get_imported_source_paths(
-                    import_path, source_ids_checked=source_ids_checked
-                )
-                for indirect_import in indirect_imports:
-                    return_set.add(indirect_import)
-
-            return return_set
-
-        # Add imported source files to list of contracts to compile.
-        source_paths_to_compile = {p for p in contract_filepaths}
-        for source_path in contract_filepaths:
-            imported_source_paths = get_imported_source_paths(source_path)
-            for imported_source in imported_source_paths:
-                source_paths_to_compile.add(imported_source)
-
-        def _get_pragma_spec(path: Path) -> Optional[NpmSpec]:
-            pragma_spec = get_pragma_spec(path)
-            if not pragma_spec:
-                return None
-
-            # Check if we need to install specified compiler version
-            if pragma_spec is pragma_spec.select(self.installed_versions):
-                return pragma_spec
-
-            solc_version = pragma_spec.select(self.available_versions)
-            if solc_version:
-                solcx.install_solc(solc_version, show_progress=False)
-            else:
-                raise CompilerError(
-                    f"Solidity version specification '{pragma_spec}' could not be met."
-                )
-
-            return pragma_spec
-
-        # Build map of pragma-specs.
-        source_by_pragma_spec = {p: _get_pragma_spec(p) for p in source_paths_to_compile}
-
-        def get_best_version(path: Path) -> Version:
-            pragma_spec = source_by_pragma_spec[path]
-            return (
-                pragma_spec.select(self.installed_versions)
-                if pragma_spec
-                else max(self.installed_versions)
-            )
-
-        # Adjust best-versions based on imports.
-        files_by_solc_version: Dict[Version, Set[Path]] = {}
-        for source_file_path in source_paths_to_compile:
-            solc_version = get_best_version(source_file_path)
-            imported_source_paths = get_imported_source_paths(source_file_path)
-
-            for imported_source_path in imported_source_paths:
-                imported_pragma_spec = source_by_pragma_spec[imported_source_path]
-                imported_version = get_best_version(imported_source_path)
-
-                if imported_pragma_spec is not None and (
-                    imported_pragma_spec.expression.startswith("=")
-                    or imported_pragma_spec.expression[0].isdigit()
-                ):
-                    # Have to use this version.
-                    solc_version = imported_version
-                    break
-
-                elif imported_version < solc_version:
-                    # If we get here, the highest version of an import is lower than the reference.
-                    solc_version = imported_version
-
-            if solc_version not in files_by_solc_version:
-                files_by_solc_version[solc_version] = set()
-
-            for path in (source_file_path, *imported_source_paths):
-                files_by_solc_version[solc_version].add(path)
-
-        contract_types: List[ContractType] = []
+        files_by_solc_version = self.get_version_map(contract_filepaths, base_path=contracts_path)
         if not files_by_solc_version:
-            return contract_types
+            return []
 
         base_kwargs = {
             "output_values": [
@@ -305,27 +217,7 @@ class SolidityCompiler(CompilerAPI):
             ],
             "optimize": self.config.optimize,
         }
-
-        # If being used in another version AND no imports in this version require it,
-        # remove it from this version.
-        for solc_version, files in files_by_solc_version.copy().items():
-            for file in files.copy():
-                used_in_other_version = any(
-                    [file in ls for v, ls in files_by_solc_version.items() if v != solc_version]
-                )
-                if not used_in_other_version:
-                    continue
-
-                other_files = [f for f in files_by_solc_version[solc_version] if f != file]
-                for other_file in other_files:
-                    source_id = str(get_relative_path(path, contracts_path))
-                    import_paths = [contracts_path / i for i in imports.get(source_id, []) if i]
-                    if file in import_paths:
-                        continue
-
-                files_by_solc_version[solc_version].remove(file)
-
-        files_by_solc_version = {v: f for v, f in files_by_solc_version.items() if f}
+        contract_types: List[ContractType] = []
         solc_versions_by_source_id: Dict[str, Version] = {}
         for solc_version, files in files_by_solc_version.items():
             cli_base_path = contracts_path if solc_version >= Version("0.6.9") else None
@@ -459,6 +351,124 @@ class SolidityCompiler(CompilerAPI):
             imports_dict[str(source_id)] = list(import_set)
 
         return imports_dict
+
+    def get_version_map(
+        self, contract_filepaths: List[Path], base_path: Optional[Path] = None
+    ) -> Dict[Version, Set[Path]]:
+        contracts_path = base_path or self.config_manager.contracts_folder
+        imports = self.get_imports(get_all_files_in_directory(contracts_path), contracts_path)
+
+        def get_imported_source_paths(
+            path: Path, source_ids_checked: Optional[List[str]] = None
+        ) -> Set[Path]:
+            source_ids_checked = source_ids_checked or []
+            source_id = str(get_relative_path(path, contracts_path))
+            if source_id in source_ids_checked:
+                # Already got this source's imports
+                return set()
+
+            source_ids_checked.append(source_id)
+            import_paths = [contracts_path / i for i in imports.get(source_id, []) if i]
+            return_set = {i for i in import_paths}
+            for import_path in import_paths:
+                indirect_imports = get_imported_source_paths(
+                    import_path, source_ids_checked=source_ids_checked
+                )
+                for indirect_import in indirect_imports:
+                    return_set.add(indirect_import)
+
+            return return_set
+
+        # Add imported source files to list of contracts to compile.
+        source_paths_to_compile = {p for p in contract_filepaths}
+        for source_path in contract_filepaths:
+            imported_source_paths = get_imported_source_paths(source_path)
+            for imported_source in imported_source_paths:
+                source_paths_to_compile.add(imported_source)
+
+        def _get_pragma_spec(path: Path) -> Optional[NpmSpec]:
+            pragma_spec = get_pragma_spec(path)
+            if not pragma_spec:
+                return None
+
+            # Check if we need to install specified compiler version
+            if pragma_spec is pragma_spec.select(self.installed_versions):
+                return pragma_spec
+
+            solc_version = pragma_spec.select(self.available_versions)
+            if solc_version:
+                solcx.install_solc(solc_version, show_progress=False)
+            else:
+                raise CompilerError(
+                    f"Solidity version specification '{pragma_spec}' could not be met."
+                )
+
+            return pragma_spec
+
+        # Build map of pragma-specs.
+        source_by_pragma_spec = {p: _get_pragma_spec(p) for p in source_paths_to_compile}
+
+        def get_best_version(path: Path) -> Version:
+            pragma_spec = source_by_pragma_spec[path]
+            return (
+                pragma_spec.select(self.installed_versions)
+                if pragma_spec
+                else max(self.installed_versions)
+            )
+
+        # Adjust best-versions based on imports.
+        files_by_solc_version: Dict[Version, Set[Path]] = {}
+        for source_file_path in source_paths_to_compile:
+            solc_version = get_best_version(source_file_path)
+            imported_source_paths = get_imported_source_paths(source_file_path)
+
+            for imported_source_path in imported_source_paths:
+                imported_pragma_spec = source_by_pragma_spec[imported_source_path]
+                imported_version = get_best_version(imported_source_path)
+
+                if imported_pragma_spec is not None and (
+                    imported_pragma_spec.expression.startswith("=")
+                    or imported_pragma_spec.expression[0].isdigit()
+                ):
+                    # Have to use this version.
+                    solc_version = imported_version
+                    break
+
+                elif imported_version < solc_version:
+                    # If we get here, the highest version of an import is lower than the reference.
+                    solc_version = imported_version
+
+            if solc_version not in files_by_solc_version:
+                files_by_solc_version[solc_version] = set()
+
+            for path in (source_file_path, *imported_source_paths):
+                files_by_solc_version[solc_version].add(path)
+
+        # If being used in another version AND no imports in this version require it,
+        # remove it from this version.
+        for solc_version, files in files_by_solc_version.copy().items():
+            for file in files.copy():
+                used_in_other_version = any(
+                    [file in ls for v, ls in files_by_solc_version.items() if v != solc_version]
+                )
+                if not used_in_other_version:
+                    continue
+
+                other_files = [f for f in files_by_solc_version[solc_version] if f != file]
+                used_in_imports = False
+                for other_file in other_files:
+                    source_id = str(get_relative_path(other_file, contracts_path))
+                    import_paths = [contracts_path / i for i in imports.get(source_id, []) if i]
+                    if file in import_paths:
+                        used_in_imports = True
+                        break
+
+                if not used_in_imports:
+                    files_by_solc_version[solc_version].remove(file)
+                    if not files_by_solc_version[solc_version]:
+                        del files_by_solc_version[solc_version]
+
+        return files_by_solc_version
 
 
 def _load_dict(data: Union[str, dict]) -> Dict:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 from ape.contracts import ContractContainer
-from semantic_version import Version
+from semantic_version import Version  # type: ignore
 
 BASE_PATH = Path(__file__).parent / "contracts"
 TEST_CONTRACT_PATHS = [p for p in BASE_PATH.iterdir() if ".cache" not in str(p) and not p.is_dir()]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -2,6 +2,7 @@ from pathlib import Path
 
 import pytest
 from ape.contracts import ContractContainer
+from semantic_version import Version
 
 BASE_PATH = Path(__file__).parent / "contracts"
 TEST_CONTRACT_PATHS = [p for p in BASE_PATH.iterdir() if ".cache" not in str(p) and not p.is_dir()]
@@ -91,3 +92,18 @@ def test_compile_single_source_with_no_imports(compiler, config):
     path = Path(__file__).parent / "DependencyOfDependency"
     with config.using_project(path) as project:
         assert type(project.DependencyOfDependency) == ContractContainer
+
+
+def test_get_version_map(project, compiler):
+    # Files are selected in order to trigger `CompilesOnce.sol` to
+    # get removed from version '0.8.12'.
+    file_paths = [
+        project.contracts_folder / "ImportSourceWithEqualSignVersion.sol",
+        project.contracts_folder / "SpecificVersionNoPrefix.sol",
+        project.contracts_folder / "CompilesOnce.sol",
+    ]
+    version_map = compiler.get_version_map(file_paths)
+    expected_version = Version("0.8.12")
+    assert len(version_map) == 1
+    assert expected_version in version_map
+    assert all([f in version_map[expected_version] for f in file_paths])


### PR DESCRIPTION
### What I did

Before, there were some dangling files that got compiled at higher versions as well as their lower, required versions. Now, the dangling sources are removed. This fundamentally  changes nothing except makes it little faster. It is a weird loop, but this ultimately removes all cruft form being passed to the `solc` compiler and seems faster probably because of this. Also, this is a more honest picture of the contract types because now we are using the contract types spit out by the compiler at their most honest levels in relationship to the rest of the project. Now, the project is only compiled with the versions it needs, which usually it just probably a single version, but sometimes there are more challenging repos out there! 😉 

Note: if a single source file is actually requires by multiple versions, the final manifest is built only using the latest version. This seems liked an edge case but still wanted to point it out.

### How I did it

There are two properties of a cruft source:

1. It is being used already in another solc version file set
2. It is NOT being imported by any other first-level sister file in its current solc version set.

If both of those things are true, that means the source file is able to be compiled at this version but it does nobody else any good and only causes the final `PackageManifest` to be a little incorrect.

### How to verify it

Things still work as expected.
I had to refactor to be able to test this.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
