### PR TITLE
fix: install latest solc if no pragma-specs found

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -390,8 +390,8 @@ class SolidityCompiler(CompilerAPI):
         # Build map of pragma-specs.
         source_by_pragma_spec = {p: self._get_pragma_spec(p) for p in source_paths_to_compile}
 
-        # If not Solidity version has been auto-installed while fetching the
-        # contract versions, we must install the latest compiler
+        # If no Solidity version has been installed previously while fetching the
+        # contract version pragma, we must install a compiler, so choose the latest
         if not self.installed_versions and not any(source_by_pragma_spec.values()):
             solcx.install_solc(max(self.available_versions), show_progress=False)
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -390,6 +390,11 @@ class SolidityCompiler(CompilerAPI):
         # Build map of pragma-specs.
         source_by_pragma_spec = {p: self._get_pragma_spec(p) for p in source_paths_to_compile}
 
+        # If not Solidity version has been auto-installed while fetching the
+        # contract versions, we must install the latest compiler
+        if not self.installed_versions and not any(source_by_pragma_spec.values()):
+            solcx.install_solc(max(self.available_versions), show_progress=False)
+
         # Adjust best-versions based on imports.
         files_by_solc_version: Dict[Version, Set[Path]] = {}
         for source_file_path in source_paths_to_compile:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,26 @@ from tempfile import mkdtemp
 
 import ape
 import pytest
+import solcx  # type: ignore
 
 # NOTE: Ensure that we don't use local paths for these
 ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
 ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
+
+
+@pytest.fixture()
+def temp_solcx_path(monkeypatch):
+    solcx_install_path = mkdtemp()
+
+    monkeypatch.setenv(
+        solcx.install.SOLCX_BINARY_PATH_VARIABLE,
+        solcx_install_path,
+    )
+
+    yield solcx_install_path
+
+    if Path(solcx_install_path).is_dir():
+        shutil.rmtree(solcx_install_path, ignore_errors=True)
 
 
 @pytest.fixture

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pytest
+import solcx  # type: ignore
 from ape.contracts import ContractContainer
 from semantic_version import Version  # type: ignore
 
@@ -27,6 +28,26 @@ def test_compile_specific_order(project, compiler):
         project.contracts_folder / "Imports.sol",
     ]
     compiler.compile(ordered_files)
+
+
+def test_compile_missing_version(project, compiler, temp_solcx_path):
+    """
+    Test the compilation of a contract with no defined pragma spec.
+
+    The plugin should implicitly download the latest version to compile the
+    contract with. `temp_solcx_path` is used to simulate an environment without
+    compilers installed.
+    """
+    assert not solcx.get_installed_solc_versions()
+
+    contract_types = compiler.compile([project.contracts_folder / "MissingPragma.sol"])
+
+    assert len(contract_types) == 1
+
+    installed_versions = solcx.get_installed_solc_versions()
+
+    assert len(installed_versions) == 1
+    assert installed_versions[0] == max(solcx.get_installable_solc_versions())
 
 
 def test_compile_contract_with_different_name_than_file(project):


### PR DESCRIPTION
### What I did

Add logic to install the latest available Solc version if no contracts being compiled include a version

This is specific to a situation where the user is setting up a new project and has not installed Solc themselves

fixes: #51 

### How to verify it

Remove Solc installations (I just `rm -rf ~/.solcx/` since I didn't need any right now) and follow steps in #51. With this change it should no longer fail but instead leave you with the latest version of Solidity installed (solc-v0.8.15 in my case)

A test `test_compile_missing_version()` was also added to verify that a system without solidity installed will have the latest version downloaded if the contract being compiled does not specify a version

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
