### PR TITLE
fix: issue preventing multiple contact types defined in single source

### DIFF
--- a/tests/ProjectWithinProject/ape-config.yaml
+++ b/tests/ProjectWithinProject/ape-config.yaml
@@ -2,6 +2,10 @@ dependencies:
   - name: TestRemapping
     local: ../Dependency
 
+  - name: TestDependencyOfDependency
+    local: ../DependencyOfDependency
+
 solidity:
   import_remapping:
     - "@remapping=TestRemapping"
+    - "@dependency_remapping=TestDependencyOfDependency/local"

--- a/tests/contracts/MultipleDefinitions.sol
+++ b/tests/contracts/MultipleDefinitions.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.12;
+
+interface IMultipleDefinitions {
+    function foo() external;
+}
+
+contract MultipleDefinitions is IMultipleDefinitions {
+    function foo() external {}
+}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -28,6 +28,9 @@ def test_compile_multiple_definitions_in_source(project, compiler):
     assert [r.name for r in result] == ["IMultipleDefinitions", "MultipleDefinitions"]
     assert all(r.source_id == "MultipleDefinitions.sol" for r in result)
 
+    assert project.MultipleDefinitions
+    assert project.IMultipleDefinitions
+
 
 def test_compile_specific_order(project, compiler):
     # NOTE: This test seems random but it's important!


### PR DESCRIPTION
### What I did

Issue where if you defined multiple contract types in a single source file, you would only get one of them returned.

### How I did it

Correct version filtering logic to be by contract name instead of source ID to prevent accidental filtering

### How to verify it

Can now compile projects that defined multiple contract types in a single source, such as https://github.com/pandadefi/registry/blob/master/contracts/VaultRegistry.sol

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
