### PR TITLE
test: use auto-generated solcx install path

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,3 +47,12 @@ If you are opening a work-in-progress pull request to verify that it passes CI t
 [marking it as a draft](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests).
 
 Join the Ethereum Python [Discord](https://discord.gg/PcEJ54yX) if you have any questions.
+
+## Testing
+
+By default, the test suite will use a new, temporary path for the Solidity compiler installations.
+This ensures that the tests always run from a clean slate without any relying on existing installations.
+
+If you wish to use your existing `~/.solcx` installations instead, you must set the environment variable `APE_SOLIDITY_USE_SYSTEM_SOLC=1`.
+
+This will ensure that py-solc-x's default path will be used, but any compilers installed as part of the tests will not be removed after tests have completed.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 from contextlib import contextmanager
 from distutils.dir_util import copy_tree
@@ -28,7 +29,10 @@ def _tmp_solcx_path(monkeypatch):
         shutil.rmtree(solcx_install_path, ignore_errors=True)
 
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(
+    scope="session",
+    autouse=os.environ.get("APE_SOLIDITY_USE_SYSTEM_SOLC") is None,
+)
 def setup_session_solcx_path(request):
     """
     Creates a new, temporary installation path for solcx when the test suite is


### PR DESCRIPTION
### What I did

Separated the test suite's solc installations from the user's, which also ensures the tests
start from a clean slate on each run

fixes: #57

### How I did it

Added a session scoped, auto-used pytest fixture for setting the install path at startup and cleaning it up at teardown

### How to verify it

Clean out your `~/.solcx` directory, run the tests, and verify that no solc installations are there after the suite completes.

Also should note starting up the test suite may take a tiny bit longer just because it's now downloading the solc binaries when it needs them, rather than relying on the real installations that may be present.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
