### PR TITLE
chore: relax pin on packaging package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
         "py-solc-x>=1.1.0,<1.2.0",
         "eth-ape>=0.4.0,<0.5.0",
         "ethpm-types",  # Use the version ape requires
-        "packaging>=20.9,<21",
+        "packaging",  # Use the version ape requires
         "requests",
     ],
     python_requires=">=3.7.2,<4",


### PR DESCRIPTION
### What I did

This package is causing warnings to show in tests because it is pinned to an older verison. It is also a dependency in `eth-ape`. I tried to update it there but noticed it broke this plugin because of its own pinning of the package. This PR relaxes the pin so we can upgrade it in ape without breaking it in `ape-solidity`.

### How I did it

Copy what we do for other shared dependencies with `eth-ape`.

### How to verify it

Things still work (Tests pass probably suffices).

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
