### PR TITLE
refactor: make settings like settings schema from solidity input JSON

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -213,10 +213,18 @@ class SolidityCompiler(CompilerAPI):
         files_by_solc_version = self.get_version_map(contract_filepaths, base_path=contracts_path)
         if not files_by_solc_version:
             return {}
-        settings_map = self._get_compiler_settings(files_by_solc_version, contracts_path)
-        return settings_map
 
-    def _get_compiler_settings(self, version_map: Dict, base_path: Path) -> Dict[Version, Dict]:
+        compiler_args = self._get_compiler_arguments(files_by_solc_version, contracts_path)
+        settings = {}
+        for vers, arguments in compiler_args.items():
+            settings[vers] = {
+                "remappings": arguments.get("import_remappings", []),
+                "optimizer": {"enabled": arguments.get("optimize", False)},
+            }
+
+        return settings
+
+    def _get_compiler_arguments(self, version_map: Dict, base_path: Path) -> Dict[Version, Dict]:
         import_remappings = self.get_import_remapping(base_path=base_path)
         base_settings = {
             "output_values": [
@@ -254,7 +262,7 @@ class SolidityCompiler(CompilerAPI):
     ) -> List[ContractType]:
         contracts_path = base_path or self.config_manager.contracts_folder
         files_by_solc_version = self.get_version_map(contract_filepaths, base_path=contracts_path)
-        settings_map = self._get_compiler_settings(files_by_solc_version, base_path=contracts_path)
+        settings_map = self._get_compiler_arguments(files_by_solc_version, base_path=contracts_path)
         contract_types: List[ContractType] = []
         solc_versions_by_contract_name: Dict[str, Version] = {}
         for solc_version, settings in settings_map.items():

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -167,42 +167,22 @@ def test_compiler_data_in_manifest(project):
     assert compiler_0426.name == "solidity"
 
     # Compiler settings test
-    assert compiler_0812.settings["optimize"] is True
-    assert compiler_0612.settings["optimize"] is True
-    assert compiler_0426.settings["optimize"] is True
-
-    # Output values test
-    output_values = [
-        "abi",
-        "bin",
-        "bin-runtime",
-        "devdoc",
-        "userdoc",
-    ]
-    assert compiler_0812.settings["output_values"] == output_values
-    assert compiler_0612.settings["output_values"] == output_values
-    assert compiler_0426.settings["output_values"] == output_values
-
-    # Import remappings test
+    assert compiler_0812.settings["optimizer"]["enabled"] is True
+    assert compiler_0612.settings["optimizer"]["enabled"] is True
+    assert compiler_0426.settings["optimizer"]["enabled"] is True
     remappings = {
         "@remapping/contracts": ".cache/TestDependency/local",
         "@remapping_2": ".cache/TestDependency/local",
         "@brownie": ".cache/BrownieDependency/local",
         "@dependency_remapping": ".cache/TestDependencyOfDependency/local",
     }
-    assert compiler_0812.settings["import_remappings"] == remappings
-    assert compiler_0612.settings["import_remappings"] == remappings
+    assert compiler_0812.settings["remappings"] == remappings
+    assert compiler_0612.settings["remappings"] == remappings
     # 0426 should have absolute paths here due to lack of base_path
     absolute_remappings = {
         prefix: str(project.contracts_folder / path) for prefix, path in remappings.items()
     }
-    assert compiler_0426.settings["import_remappings"] == absolute_remappings
-
-    # Base path test
-    assert compiler_0812.settings["base_path"]
-    assert compiler_0612.settings["base_path"]
-    # 0426 does not have base path
-    assert "base_path" not in compiler_0426.settings
+    assert compiler_0426.settings["remappings"] == absolute_remappings
 
     # Compiler contract types test
     assert set(compiler_0812.contractTypes) == {


### PR DESCRIPTION
### What I did

Changes settings schema to match what is defined here: https://docs.soliditylang.org/en/latest/using-the-compiler.html#input-description

(in the settings key)

### How I did it

* Removed keys that were not in the settings key
* Changed schema / names to align with those docs.

### How to verify it

Things still work and settings make sense.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
