### PR TITLE
fix: issue where sometimes showed unused import remappings in settings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -16,7 +16,7 @@ $ ape plugins list
 ```
 
 * Python Version: x.x.x
-* OS: osx/linux/win
+* OS: macOS/linux/win
 
 ### What went wrong?
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,18 +4,18 @@ To get started with working on the codebase, use the following steps prepare you
 
 ```bash
 # clone the github repo and navigate into the folder
-git clone https://github.com/ApeWorX/<PROJECT_NAME>.git
-cd <PROJECT_NAME>
+git clone https://github.com/ApeWorX/ape-solidity.git
+cd ape-solidity
 
 # create and load a virtual environment
 python3 -m venv venv
 source venv/bin/activate
 
-# install brownie into the virtual environment
+# install ape-solidity into the virtual environment
 python setup.py install
 
 # install the developer dependencies (-e is interactive mode)
-pip install -e .[dev]
+pip install -e .'[dev]'
 ```
 
 ## Pre-Commit Hooks

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Compile Solidity contracts.
 
 ## Dependencies
 
-* [python3](https://www.python.org/downloads) version 3.6 or greater, python3-dev
+* [python3](https://www.python.org/downloads) version 3.7.2 or greater, python3-dev
 
 ## Installation
 

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -1,0 +1,77 @@
+import json
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Set, Union
+
+from ape.logging import logger
+from semantic_version import NpmSpec  # type: ignore
+
+
+def get_import_lines(source_paths: Set[Path]) -> Dict[Path, List[str]]:
+    imports_dict: Dict[Path, List[str]] = {}
+
+    for filepath in source_paths:
+        import_set = set()
+        source_lines = filepath.read_text().splitlines()
+        line_number = 0
+        for ln in source_lines:
+            if not ln.startswith("import"):
+                continue
+
+            if ";" in ln:
+                import_str = ln
+
+            else:
+                # Is multi-line.
+                import_str = ln
+                start_index = line_number + 1
+                for next_ln in source_lines[start_index:]:
+                    import_str += f" {next_ln.strip()}"
+
+                    if ";" in next_ln:
+                        break
+
+            import_set.add(import_str)
+            line_number += 1
+
+        imports_dict[filepath] = list(import_set)
+
+    return imports_dict
+
+
+def get_pragma_spec(source_file_path: Path) -> Optional[NpmSpec]:
+    """
+    Extracts pragma information from Solidity source code.
+    Args:
+        source_file_path: Solidity source code
+    Returns: NpmSpec object or None, if no valid pragma is found
+    """
+    if not source_file_path.is_file():
+        return None
+
+    source = source_file_path.read_text()
+    pragma_match = next(re.finditer(r"(?:\n|^)\s*pragma\s*solidity\s*([^;\n]*)", source), None)
+    if pragma_match is None:
+        return None  # Try compiling with latest
+
+    # The following logic handles the case where the user puts a space
+    # between the operator and the version number in the pragam string,
+    # such as `solidity >= 0.4.19 < 0.7.0`.
+    pragma_expression = ""
+    pragma_parts = pragma_match.groups()[0].split()
+    num_parts = len(pragma_parts)
+    for index in range(num_parts):
+        pragma_expression += pragma_parts[index]
+        if any([c.isdigit() for c in pragma_parts[index]]) and index < num_parts - 1:
+            pragma_expression += " "
+
+    try:
+        return NpmSpec(pragma_expression)
+
+    except ValueError as err:
+        logger.error(str(err))
+        return None
+
+
+def load_dict(data: Union[str, dict]) -> Dict:
+    return data if isinstance(data, dict) else json.loads(data)

--- a/ape_solidity/exceptions.py
+++ b/ape_solidity/exceptions.py
@@ -1,0 +1,9 @@
+from ape.exceptions import ConfigError
+
+
+class IncorrectMappingFormatError(ConfigError):
+    def __init__(self):
+        super().__init__(
+            "Incorrectly formatted 'solidity.remapping' config property. "
+            "Expected '@value_1=value2'."
+        )

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -115,12 +115,6 @@ def test_get_import_remapping(compiler, project, config):
     assert import_remapping != second_import_remapping
 
 
-def test_get_import_remapping_specify_sources(compiler, project):
-    source = project.contracts_folder / "ImportOlderDependency.sol"
-    import_remapping = compiler.get_import_remapping(source_paths={source})
-    assert import_remapping == {"@remapping/contracts": ".cache/TestDependency/local"}
-
-
 def test_brownie_project(compiler, config):
     brownie_project_path = Path(__file__).parent / "BrownieProject"
     with config.using_project(brownie_project_path) as project:
@@ -183,18 +177,19 @@ def test_compiler_data_in_manifest(project):
     assert "remappings" not in compiler_0812.settings
     assert "remappings" not in compiler_0612.settings
 
+    common_suffix = ".cache/TestDependency/local"
     expected_remappings = {
-        "@remapping/contracts": ".cache/TestDependency/local",
-        "@remapping_2": ".cache/TestDependency/local",
-        "@brownie": ".cache/BrownieDependency/local",
-        "@dependency_remapping": ".cache/TestDependencyOfDependency/local",
+        f"@remapping/contracts={common_suffix}",
+        f"@remapping_2={common_suffix}",
+        "@brownie=.cache/BrownieDependency/local",
+        "@dependency_remapping=.cache/TestDependencyOfDependency/local",
     }
     assert compiler_0816.settings["remappings"] == expected_remappings
     # 0.4.26 should have absolute paths here due to lack of base_path
-    expected_0426_remappings = {
-        "@remapping/contracts": str(project.contracts_folder / ".cache/TestDependency/local")
-    }
-    assert compiler_0426.settings["remappings"] == expected_0426_remappings
+    assert (
+        f"@remapping/contracts={project.contracts_folder}/{common_suffix}"
+        in compiler_0426.settings["remappings"]
+    )
 
     # Compiler contract types test
     assert set(compiler_0812.contractTypes) == {


### PR DESCRIPTION
### What I did

Allow getting import remappings to filter by the given source paths.
This allows us to remove unused remappings from settings if possible.

### How I did it

Read the lines of the source files and only use remappings from config if present

### How to verify it

* Have a bunch of remappings in config e.g.

```yaml
solidity:
  import_remapping:
    - "@openzeppelin/contracts=OpenZeppelin/4.6.0"
    - "@openzeppelin=OpenZeppelin/4.6.0"
    - "@solidity-bytes-utils/contracts=solidity-bytes-utils/v0.8.0"
```

* Have a source file only use one of them e.g.:

```solidity
// SPDX-License-Identifier: MIT
pragma solidity ^0.8.2;
import "@openzeppelin/contracts/<something>";
contract Contract {
    address public owner;
}
```

Check settings and make sure only the 1 shows:

```python
project.extract_manifest().compilers[0].settings["remappings"]
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
