### PR TITLE
fix: bug where compiler errored in projects with Vyper files

### DIFF
--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -3,6 +3,7 @@ import re
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
+from ape.exceptions import CompilerError
 from ape.logging import logger
 from semantic_version import NpmSpec  # type: ignore
 
@@ -78,4 +79,9 @@ def load_dict(data: Union[str, dict]) -> Dict:
 
 
 def verify_contract_filepaths(contract_filepaths: List[Path]) -> Set[Path]:
-    return {p for p in contract_filepaths if p.suffix == ".sol"}
+    invalid_files = [p.name for p in contract_filepaths if p.suffix != ".sol"]
+    if not invalid_files:
+        return set(contract_filepaths)
+
+    sources_str = "', '".join(invalid_files)
+    raise CompilerError(f"Unable to compile '{sources_str}' using Solidity compiler.")

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -180,12 +180,12 @@ class SolidityCompiler(CompilerAPI):
     def get_compiler_settings(
         self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> Dict[Version, Dict]:
-        contracts_path = base_path or self.config_manager.contracts_folder
-        files_by_solc_version = self.get_version_map(contract_filepaths, base_path=contracts_path)
+        base_path = base_path or self.config_manager.contracts_folder
+        files_by_solc_version = self.get_version_map(contract_filepaths, base_path=base_path)
         if not files_by_solc_version:
             return {}
 
-        compiler_args = self._get_compiler_arguments(files_by_solc_version, contracts_path)
+        compiler_args = self._get_compiler_arguments(files_by_solc_version, base_path)
         settings: Dict = {}
         for vers, arguments in compiler_args.items():
             sources = files_by_solc_version[vers]
@@ -474,22 +474,22 @@ class SolidityCompiler(CompilerAPI):
     def _get_imported_source_paths(
         self,
         path: Path,
-        contracts_path: Path,
+        base_path: Path,
         imports: Dict,
         source_ids_checked: Optional[List[str]] = None,
     ) -> Set[Path]:
         source_ids_checked = source_ids_checked or []
-        source_identifier = str(get_relative_path(path, contracts_path))
+        source_identifier = str(get_relative_path(path, base_path))
         if source_identifier in source_ids_checked:
             # Already got this source's imports
             return set()
 
         source_ids_checked.append(source_identifier)
-        import_file_paths = [contracts_path / i for i in imports.get(source_identifier, []) if i]
+        import_file_paths = [base_path / i for i in imports.get(source_identifier, []) if i]
         return_set = {i for i in import_file_paths}
         for import_path in import_file_paths:
             indirect_imports = self._get_imported_source_paths(
-                import_path, contracts_path, imports, source_ids_checked=source_ids_checked
+                import_path, base_path, imports, source_ids_checked=source_ids_checked
             )
             for indirect_import in indirect_imports:
                 return_set.add(indirect_import)

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     install_requires=[
         "importlib-metadata ; python_version<'3.8'",
         "py-solc-x>=1.1.0,<1.2.0",
-        "eth-ape>=0.4.4,<0.5.0",
+        "eth-ape>=0.4.5,<0.5.0",
         "ethpm-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,3 +94,8 @@ def project(config):
 @pytest.fixture
 def compiler():
     return ape.compilers.registered_compilers[".sol"]
+
+
+@pytest.fixture
+def vyper_source_path(project):
+    return project.contracts_folder / "RandomVyperFile.vy"

--- a/tests/contracts/RandomVyperFile.vy
+++ b/tests/contracts/RandomVyperFile.vy
@@ -1,0 +1,10 @@
+# @version 0.3.6
+
+# NOTE: This file only exists to prove it does not interfere
+#  (we had found bugs related to this)
+
+myNumber: public(uint256)
+
+@external
+def setNumber(num: uint256):
+    self.myNumber = num

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 import solcx  # type: ignore
 from ape.contracts import ContractContainer
+from ape.exceptions import CompilerError
 from semantic_version import Version  # type: ignore
 
 BASE_PATH = Path(__file__).parent / "contracts"
@@ -79,7 +80,9 @@ def test_compile_only_returns_contract_types_for_inputs(compiler, project):
 
 
 def test_compile_vyper_contract(compiler, vyper_source_path):
-    assert not compiler.compile([vyper_source_path])
+    expected_message = "Unable to compile 'RandomVyperFile.vy' using Solidity compiler."
+    with pytest.raises(CompilerError, match=expected_message):
+        compiler.compile([vyper_source_path])
 
 
 def test_get_imports(project, compiler):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -10,7 +10,7 @@ TEST_CONTRACT_PATHS = [p for p in BASE_PATH.iterdir() if ".cache" not in str(p) 
 TEST_CONTRACTS = [str(p.stem) for p in TEST_CONTRACT_PATHS]
 
 # These are tested elsewhere, not in `test_compile`.
-normal_test_skips = ("DifferentNameThanFile", "MultipleDefinitions")
+normal_test_skips = ("DifferentNameThanFile", "MultipleDefinitions", "RandomVyperFile")
 
 
 @pytest.mark.parametrize(
@@ -78,6 +78,10 @@ def test_compile_only_returns_contract_types_for_inputs(compiler, project):
     assert contract_types[0].name == "Imports"
 
 
+def test_compile_vyper_contract(compiler, vyper_source_path):
+    assert not compiler.compile([vyper_source_path])
+
+
 def test_get_imports(project, compiler):
     import_dict = compiler.get_imports(TEST_CONTRACT_PATHS, BASE_PATH)
     contract_imports = import_dict["Imports.sol"]
@@ -93,6 +97,10 @@ def test_get_imports(project, compiler):
         ".cache/BrownieDependency/local/BrownieContract.sol",
     }
     assert set(contract_imports) == expected
+
+
+def test_get_imports_ignores_non_solidity_files(compiler, vyper_source_path):
+    assert not compiler.get_imports([vyper_source_path])
 
 
 def test_get_import_remapping(compiler, project, config):
@@ -152,6 +160,16 @@ def test_get_version_map(project, compiler):
 
     # Will fail if the import remappings have not loaded yet.
     assert all([f.is_file() for f in file_paths])
+
+
+def test_get_version_map_single_source(compiler, project):
+    # Source has no imports
+    source = project.contracts_folder / "OlderVersion.sol"
+    assert compiler.get_version_map([source]) == {Version("0.5.16"): {source}}
+
+
+def test_get_version_map_ignores_non_solidity_sources(compiler, vyper_source_path):
+    assert not compiler.get_version_map([vyper_source_path])
 
 
 def test_compiler_data_in_manifest(project):


### PR DESCRIPTION
### What I did

While investigating https://github.com/ApeWorX/ape-vyper/issues/45, noticed an issue with the solidity plugin and vyper files.

The main issue was in ape core and it was fixed there.

This PR adds tests to help ensure bugs don't return

### How I did it

Raise compiler error when non sol files given

### How to verify it

Try to compile a vyper file using the solidity compiler:

```python
from ape import compilers

compilers.registered_compilers[".sol"].compile([Path("path/to/vyper/file.vy")])
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
