### PR TITLE
fix: issue where remappings in compiler settings were not JSON compliant

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     rev: v0.982
     hooks:
     -   id: mypy
-        additional_dependencies: [types-requests, types-pkg-resources]
+        additional_dependencies: [types-requests, types-setuptools]
 
 default_language_version:
     python: python3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,21 +10,21 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.6.0
+    rev: 22.10.0
     hooks:
       - id: black
         name: black
 
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 4.0.1
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.971
+    rev: v0.982
     hooks:
     -   id: mypy
-        additional_dependencies: [types-requests]
+        additional_dependencies: [types-requests, types-pkg-resources]
 
 default_language_version:
     python: python3

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -198,7 +198,7 @@ class SolidityCompiler(CompilerAPI):
             }
             remappings = arguments.get("import_remappings")
             if remappings:
-                version_settings["remappings"] = remappings
+                version_settings["remappings"] = list(remappings)
 
             settings[vers] = version_settings
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -1,6 +1,6 @@
 import os
 from pathlib import Path
-from typing import Dict, List, Optional, Set, Tuple, Union, cast
+from typing import Any, Dict, List, Optional, Set, Tuple, Union, cast
 
 import solcx  # type: ignore
 from ape.api import CompilerAPI, PluginConfig
@@ -190,13 +190,13 @@ class SolidityCompiler(CompilerAPI):
         settings: Dict = {}
         for vers, arguments in compiler_args.items():
             sources = files_by_solc_version[vers]
-            version_settings = {
+            version_settings: Dict[str, Union[Any, List[Any]]] = {
                 "optimizer": {"enabled": arguments.get("optimize", False), "runs": 200},
                 "outputSelection": {
                     p.name: {p.stem: arguments.get("output_values", [])} for p in sources
                 },
             }
-            remappings = arguments.get("import_remappings")
+            remappings: List[str] = arguments.get("import_remappings", [])
             if remappings:
                 version_settings["remappings"] = list(remappings)
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from setuptools import find_packages, setup  # type: ignore
+from setuptools import find_packages, setup
 
 extras_require = {
     "test": [  # `test` GitHub Action jobs uses this
@@ -10,11 +10,12 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=22.6.0,<23.0",  # auto-formatter and linter
+        "black>=22.10.0,<23.0",  # auto-formatter and linter
         "mypy==0.982",  # Static type analyzer
-        "types-requests",  # NOTE: Needed due to mypy typeshed
-        "flake8>=4.0.1,<5.0",  # Style linter
-        "isort>=5.10.1,<6.0",  # Import sorting linter
+        "types-requests",  # Needed due to mypy typeshed
+        "types-pkg-resources",  # Needed due to mypy typeshed
+        "flake8>=5.0.4",  # Style linter
+        "isort>=5.10.1",  # Import sorting linter
     ],
     "doc": [
         "Sphinx>=3.4.3,<4",  # Documentation generator

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ extras_require = {
         "black>=22.10.0,<23.0",  # auto-formatter and linter
         "mypy==0.982",  # Static type analyzer
         "types-requests",  # Needed due to mypy typeshed
-        "types-pkg-resources",  # Needed due to mypy typeshed
+        "types-setuptools",  # Needed due to mypy typeshed
         "flake8>=5.0.4",  # Style linter
         "isort>=5.10.1",  # Import sorting linter
     ],

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -233,13 +233,13 @@ def test_compiler_data_in_manifest(project):
     assert "remappings" not in compiler_0612.settings
 
     common_suffix = ".cache/TestDependency/local"
-    expected_remappings = {
+    expected_remappings = (
         f"@remapping/contracts={common_suffix}",
         f"@remapping_2={common_suffix}",
         "@brownie=.cache/BrownieDependency/local",
         "@dependency_remapping=.cache/TestDependencyOfDependency/local",
-    }
-    assert compiler_latest.settings["remappings"] == expected_remappings
+    )
+    assert all(x in compiler_latest.settings["remappings"] for x in expected_remappings)
     # 0.4.26 should have absolute paths here due to lack of base_path
     assert (
         f"@remapping/contracts={project.contracts_folder}/{common_suffix}"


### PR DESCRIPTION
### What I did

The compiler settings should be JSON compliant and follow the standard JSON output format.
There was an issue however where import remappings were a set and thus not JSON encodable.
This fixes that and adds a test.

### How I did it

Convert set to list.
Add test.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
