### PR TITLE
fix: issue with multi-line import statements

### DIFF
--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -18,23 +18,20 @@ def get_import_lines(source_paths: Set[Path]) -> Dict[Path, List[str]]:
     for filepath in source_paths:
         import_set = set()
         source_lines = filepath.read_text().splitlines()
-        line_number = 0
-        for ln in source_lines:
+        num_lines = len(source_lines)
+        for line_number, ln in enumerate(source_lines):
             if not ln.startswith("import"):
                 continue
 
-            if ";" in ln:
-                import_str = ln
+            import_str = ln
+            second_line_number = line_number
+            while ";" not in import_str:
+                second_line_number += 1
+                if second_line_number >= num_lines:
+                    raise CompilerError("Import statement missing semicolon.")
 
-            else:
-                # Is multi-line.
-                import_str = ln
-                start_index = line_number + 1
-                for next_ln in source_lines[start_index:]:
-                    import_str += f" {next_ln.strip()}"
-
-                    if ";" in next_ln:
-                        break
+                next_line = source_lines[second_line_number]
+                import_str += f" {next_line.strip()}"
 
             import_set.add(import_str)
             line_number += 1

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -333,7 +333,14 @@ class SolidityCompiler(CompilerAPI):
 
         def import_str_to_source_id(_import_str: str, source_path: Path) -> str:
             quote = '"' if '"' in _import_str else "'"
-            end_index = _import_str.index(quote) + 1
+
+            try:
+                end_index = _import_str.index(quote) + 1
+            except ValueError as err:
+                raise CompilerError(
+                    f"Error parsing import statement '{_import_str}' in '{source_path.name}'."
+                ) from err
+
             import_str_prefix = _import_str[end_index:]
             import_str_value = import_str_prefix[: import_str_prefix.index(quote)]
             path = (source_path.parent / import_str_value).resolve()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=22.10.0,<23.0",  # auto-formatter and linter
+        "black>=22.10.0",  # auto-formatter and linter
         "mypy==0.982",  # Static type analyzer
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
@@ -62,7 +62,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "py-solc-x>=1.1.0,<2",
-        "eth-ape>=0.5.0,<0.6",
+        "eth-ape>=0.5.4,<0.6",
         "ethpm-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",

--- a/tests/contracts/Imports.sol
+++ b/tests/contracts/Imports.sol
@@ -3,6 +3,8 @@
 pragma solidity ^0.8.4;
 
 import * as Depend from "@remapping/contracts/Dependency.sol";
+import
+    "./././././././././././././././././././././././././././././././././././MissingPragma.sol";
 import { MyStruct } from "CompilesOnce.sol";
 import "./subfolder/Relativecontract.sol";
 import "@remapping_2/Dependency.sol" as Depend2;

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -111,6 +111,8 @@ def test_get_imports(project, compiler):
         ".cache/TestDependency/local/Dependency.sol",
         "subfolder/Relativecontract.sol",
         ".cache/BrownieDependency/local/BrownieContract.sol",
+        "MissingPragma.sol",
+        "NumerousDefinitions.sol",
     }
     assert set(contract_imports) == expected
 
@@ -187,7 +189,7 @@ def test_get_version_map(project, compiler):
     assert all([f in version_map[expected_version] for f in file_paths[:-1]])
 
     latest_version_sources = version_map[latest_version]
-    assert len(latest_version_sources) == 6, "Did the import remappings load correctly?"
+    assert len(latest_version_sources) == 8, "Did the import remappings load correctly?"
     assert file_paths[-1] in latest_version_sources
 
     # Will fail if the import remappings have not loaded yet.


### PR DESCRIPTION
### What I did

Thank you https://github.com/ApeWorX/ape-solidity/pull/77 for getting this started

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #

### How I did it

* Added the line from the linked PR as a test
* Used a similar while-loop strategy to that of the linked PR
* Mold until test passes

### How to verify it

Get multi-line imports and get `get_imports()` and make sure things work out

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
