### PR TITLE
fix: sort remappings in compiler settings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
     -   id: flake8
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v0.991
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests, types-setuptools]

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -199,7 +199,7 @@ class SolidityCompiler(CompilerAPI):
             }
             remappings: List[str] = arguments.get("import_remappings", [])
             if remappings:
-                version_settings["remappings"] = list(remappings)
+                version_settings["remappings"] = sorted(list(remappings))
 
             evm_version = arguments.get("evm_version")
             if evm_version:

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -199,6 +199,7 @@ class SolidityCompiler(CompilerAPI):
             }
             remappings: List[str] = arguments.get("import_remappings", [])
             if remappings:
+                # Standard JSON input requires remappings to be sorted.
                 version_settings["remappings"] = sorted(list(remappings))
 
             evm_version = arguments.get("evm_version")

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ extras_require = {
     ],
     "lint": [
         "black>=22.10.0",  # auto-formatter and linter
-        "mypy==0.982",  # Static type analyzer
+        "mypy>=0.991",  # Static type analyzer
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
         "flake8>=5.0.4",  # Style linter

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -237,7 +237,10 @@ def test_compiler_data_in_manifest(project):
         "@brownie=.cache/BrownieDependency/local",
         "@dependency_remapping=.cache/TestDependencyOfDependency/local",
     )
-    assert all(x in compiler_latest.settings["remappings"] for x in expected_remappings)
+    actual_remappings = compiler_latest.settings["remappings"]
+    assert all(x in actual_remappings for x in expected_remappings)
+    assert all(b >= a for a, b in zip(actual_remappings, actual_remappings[1:]))
+
     # 0.4.26 should have absolute paths here due to lack of base_path
     assert (
         f"@remapping/contracts={project.contracts_folder}/{common_suffix}"
@@ -325,6 +328,7 @@ def test_get_compiler_settings(compiler, project):
     assert isinstance(actual_remappings, list)
     assert len(actual_remappings) == len(expected_remappings)
     assert all(e in actual_remappings for e in expected_remappings)
+    assert all(b >= a for a, b in zip(actual_remappings, actual_remappings[1:]))
 
     # Tests against bug potentially preventing JSON decoding errors related
     # to contract verification.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -239,7 +239,9 @@ def test_compiler_data_in_manifest(project):
     )
     actual_remappings = compiler_latest.settings["remappings"]
     assert all(x in actual_remappings for x in expected_remappings)
-    assert all(b >= a for a, b in zip(actual_remappings, actual_remappings[1:]))
+    assert all(
+        b >= a for a, b in zip(actual_remappings, actual_remappings[1:])
+    ), "Import remappings should be sorted"
 
     # 0.4.26 should have absolute paths here due to lack of base_path
     assert (
@@ -328,7 +330,9 @@ def test_get_compiler_settings(compiler, project):
     assert isinstance(actual_remappings, list)
     assert len(actual_remappings) == len(expected_remappings)
     assert all(e in actual_remappings for e in expected_remappings)
-    assert all(b >= a for a, b in zip(actual_remappings, actual_remappings[1:]))
+    assert all(
+        b >= a for a, b in zip(actual_remappings, actual_remappings[1:])
+    ), "Import remappings should be sorted"
 
     # Tests against bug potentially preventing JSON decoding errors related
     # to contract verification.


### PR DESCRIPTION
### What I did

As per standard JSON input, the import remappings should be sorted.

### How I did it

Sort remappings and add tests verifying they are sorted in all the right places.

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
