### PR TITLE
fix: issue when contracts folder contained sub-directories with `.sol` in name

### DIFF
--- a/ape_solidity/__init__.py
+++ b/ape_solidity/__init__.py
@@ -1,6 +1,6 @@
 from ape import plugins
 
-from .compiler import SolidityCompiler, SolidityConfig
+from .compiler import Extension, SolidityCompiler, SolidityConfig
 
 
 @plugins.register(plugins.Config)
@@ -10,4 +10,4 @@ def config_class():
 
 @plugins.register(plugins.CompilerPlugin)
 def register_compiler():
-    return (".sol",), SolidityCompiler
+    return (Extension.SOL.value,), SolidityCompiler

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -1,6 +1,7 @@
 import json
 import re
 import subprocess
+from enum import Enum
 from pathlib import Path
 from typing import Dict, List, Optional, Set, Union
 
@@ -10,6 +11,10 @@ from semantic_version import NpmSpec, Version  # type: ignore
 from solcx.exceptions import SolcError  # type: ignore
 from solcx.install import get_executable  # type: ignore
 from solcx.wrapper import VERSION_REGEX  # type: ignore
+
+
+class Extension(Enum):
+    SOL = ".sol"
 
 
 def get_import_lines(source_paths: Set[Path]) -> Dict[Path, List[str]]:
@@ -97,7 +102,7 @@ def get_version_with_commit_hash(version: Union[str, Version]) -> Version:
 
 
 def verify_contract_filepaths(contract_filepaths: List[Path]) -> Set[Path]:
-    invalid_files = [p.name for p in contract_filepaths if p.suffix != ".sol"]
+    invalid_files = [p.name for p in contract_filepaths if p.suffix != Extension.SOL.value]
     if not invalid_files:
         return set(contract_filepaths)
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -16,6 +16,7 @@ from semantic_version import NpmSpec, Version  # type: ignore
 from solcx.install import get_executable  # type: ignore
 
 from ape_solidity._utils import (
+    Extension,
     get_import_lines,
     get_pragma_spec,
     get_version_with_commit_hash,
@@ -401,7 +402,11 @@ class SolidityCompiler(CompilerAPI):
 
         base_path = base_path or self.project_manager.contracts_folder
         contract_filepaths_set = verify_contract_filepaths(contract_filepaths)
-        sources = [p for p in self.project_manager.source_paths if p.suffix == ".sol"]
+        sources = [
+            p
+            for p in self.project_manager.source_paths
+            if p.is_file() and p.suffix == Extension.SOL.value
+        ]
         imports = self.get_imports(sources, base_path)
 
         # Add imported source files to list of contracts to compile.

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -183,8 +183,19 @@ class SolidityCompiler(CompilerAPI):
     def get_compiler_settings(
         self, contract_filepaths: List[Path], base_path: Optional[Path] = None
     ) -> Dict[Version, Dict]:
+
+        # Currently needed because of a bug in Ape core 0.5.5.
+        only_files = []
+        for path in contract_filepaths:
+            if path.is_dir():
+                logger.error(
+                    f"Unable to get compiler settings for directory '{path.name}'. Skipping."
+                )
+            else:
+                only_files.append(path)
+
         base_path = base_path or self.config_manager.contracts_folder
-        files_by_solc_version = self.get_version_map(contract_filepaths, base_path=base_path)
+        files_by_solc_version = self.get_version_map(only_files, base_path=base_path)
         if not files_by_solc_version:
             return {}
 

--- a/tests/BrownieProject/ape-config.yaml
+++ b/tests/BrownieProject/ape-config.yaml
@@ -1,0 +1,9 @@
+contracts_folder: contracts
+dependencies:
+- github: OpenZeppelin/openzeppelin-contracts
+  name: OpenZeppelin
+  version: 3.1.0
+solidity:
+  import_remapping:
+  - '@openzeppelin/contracts=OpenZeppelin/3.1.0'
+  version: 0.8.12

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,8 @@ import ape
 import pytest
 import solcx  # type: ignore
 
+from ape_solidity.compiler import Extension
+
 # NOTE: Ensure that we don't use local paths for these
 ape.config.DATA_FOLDER = Path(mkdtemp()).resolve()
 ape.config.PROJECT_FOLDER = Path(mkdtemp()).resolve()
@@ -93,7 +95,7 @@ def project(config):
 
 @pytest.fixture
 def compiler():
-    return ape.compilers.registered_compilers[".sol"]
+    return ape.compilers.registered_compilers[Extension.SOL.value]
 
 
 @pytest.fixture

--- a/tests/contracts/DirectoryWithExtension.sol/README.md
+++ b/tests/contracts/DirectoryWithExtension.sol/README.md
@@ -1,0 +1,3 @@
+# Directory with Misleading Extension Test
+
+The existence of this directory is to test things still work when a directory with `.sol` in its name is present.

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -9,11 +9,13 @@ from ape.contracts import ContractContainer
 from ape.exceptions import CompilerError
 from semantic_version import Version  # type: ignore
 
+from ape_solidity import Extension
+
 BASE_PATH = Path(__file__).parent / "contracts"
 TEST_CONTRACT_PATHS = [
     p
     for p in BASE_PATH.iterdir()
-    if ".cache" not in str(p) and not p.is_dir() and p.suffix == ".sol"
+    if ".cache" not in str(p) and not p.is_dir() and p.suffix == Extension.SOL.value
 ]
 TEST_CONTRACTS = [str(p.stem) for p in TEST_CONTRACT_PATHS]
 PATTERN_REQUIRING_COMMIT_HASH = re.compile(r"\d+\.\d+\.\d+\+commit\.[\d|a-f]+")


### PR DESCRIPTION
### What I did

Fixes issue where could not have directory with `.sol` in the name.
Note: It is fixed in 1 spot here and 2 spots in core: https://github.com/ApeWorX/ape/pull/1147
So tests will fail until core is released.
Edit: Make a hack so that it WARNs and still works without the need of an ape core release. So now, the warning will go away after the next release but it is not going to block anyone.

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
