### PR TITLE
test: ensure dependencies that don't fully compile are usable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.DS_Store
+*.swp
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -254,12 +254,7 @@ class SolidityCompiler(CompilerAPI):
                 )
                 for source in resolved_remapped_sources:
                     parent_key = os.path.sep.join(source.split(os.path.sep)[:3])
-
                     for k, v in [(k, v) for k, v in import_remappings.items() if parent_key in v]:
-
-                        if "0.6.12" in str(solc_version):
-                            breakpoint()
-
                         remappings_kept.add(f"{k}={v}")
 
             arguments = {

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -151,10 +151,7 @@ class SolidityCompiler(CompilerAPI):
             sub_contracts_cache = contracts_cache / suffix
             if not sub_contracts_cache.is_dir() or not list(sub_contracts_cache.iterdir()):
                 cached_manifest_file = data_folder_cache / f"{name}.json"
-                if not cached_manifest_file.is_file():
-                    logger.warning(f"Unable to find dependency '{suffix}'.")
-
-                else:
+                if cached_manifest_file.is_file():
                     manifest = PackageManifest.parse_file(cached_manifest_file)
                     sub_contracts_cache.mkdir(parents=True)
                     sources = manifest.sources or {}

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -151,7 +151,10 @@ class SolidityCompiler(CompilerAPI):
             sub_contracts_cache = contracts_cache / suffix
             if not sub_contracts_cache.is_dir() or not list(sub_contracts_cache.iterdir()):
                 cached_manifest_file = data_folder_cache / f"{name}.json"
-                if cached_manifest_file.is_file():
+                if not cached_manifest_file.is_file():
+                    logger.debug(f"Unable to find dependency '{suffix}'.")
+
+                else:
                     manifest = PackageManifest.parse_file(cached_manifest_file)
                     sub_contracts_cache.mkdir(parents=True)
                     sources = manifest.sources or {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ write_to = "ape_solidity/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "py-solc-x>=1.1.0,<2",
-        "eth-ape>=0.5.4,<0.6",
+        "eth-ape>=0.5.7,<0.6",
         "ethpm-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",

--- a/tests/BrownieStyleDependency/contracts/BrownieStyleDependency.sol
+++ b/tests/BrownieStyleDependency/contracts/BrownieStyleDependency.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+contract BrownieStyleDependency {
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/BrownieStyleDependency/contracts/FailingContract.sol
+++ b/tests/BrownieStyleDependency/contracts/FailingContract.sol
@@ -1,0 +1,2 @@
+This file exists to show that a brownie-style dependency can contain a contract that does not compile.
+But the dependency is still usable (provided the project only uses working contract types)

--- a/tests/BrownieStyleDependency/contracts/FailingContract.sol
+++ b/tests/BrownieStyleDependency/contracts/FailingContract.sol
@@ -1,2 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
 This file exists to show that a brownie-style dependency can contain a contract that does not compile.
 But the dependency is still usable (provided the project only uses working contract types)

--- a/tests/DependencyOfDependency/ape-config.yaml
+++ b/tests/DependencyOfDependency/ape-config.yaml
@@ -1,0 +1,3 @@
+contracts_folder: contracts
+name: TestDependencyOfDependency
+version: local

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -2,8 +2,15 @@ dependencies:
   - name: TestDependency
     local: ./Dependency
 
+  # Make sure can use a Brownie project as a dependency
   - name: BrownieDependency
     local: ./BrownieProject
+
+  # Make sure can use a Brownie-style dependency.
+  # Brownie-style dependencies don't compile on their own, necessarily
+  # and are more a collection of contract types you can use.
+  - name: BrownieStyleDependency
+    local: ./BrownieStyleDependency
 
   # NOTE: Currently have to specify dependencies of dependencies
   - name: TestDependencyOfDependency
@@ -14,6 +21,10 @@ solidity:
     - "@remapping/contracts=TestDependency"
     - "@remapping_2=TestDependency"
     - "@brownie=BrownieDependency"
+
+    # Remapping for showing we can import a contract type from a brownie-style dependency
+    # (provided the _single_ contract type compiles in the project).
+    - "@styleofbrownie=BrownieStyleDependency"
 
     # NOTE: Currently have to specify dependency-remappings of dependencies
     - "@dependency_remapping=TestDependencyOfDependency/local"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -77,6 +77,7 @@ def project(config):
     for path in (
         project_path,
         project_path / "BrownieProject",
+        project_path / "BrownieStyleDependency",
         project_path / "Dependency",
         project_path / "DependencyOfDependency",
         project_path / "ProjectWithinProject",

--- a/tests/contracts/Imports.sol
+++ b/tests/contracts/Imports.sol
@@ -17,6 +17,7 @@ import {
     Struct4,
     Struct5
 } from "./NumerousDefinitions.sol";
+import "@styleofbrownie/BrownieStyleDependency.sol";
 
 contract Imports {
     function foo() pure public returns(bool) {

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -109,12 +109,13 @@ def test_get_imports(project, compiler):
     assert type(contract_imports) == list
     # NOTE: in case order changes
     expected = {
-        "CompilesOnce.sol",
-        ".cache/TestDependency/local/Dependency.sol",
-        "subfolder/Relativecontract.sol",
         ".cache/BrownieDependency/local/BrownieContract.sol",
+        ".cache/BrownieStyleDependency/local/BrownieStyleDependency.sol",
+        ".cache/TestDependency/local/Dependency.sol",
+        "CompilesOnce.sol",
         "MissingPragma.sol",
         "NumerousDefinitions.sol",
+        "subfolder/Relativecontract.sol",
     }
     assert set(contract_imports) == expected
 
@@ -127,10 +128,11 @@ def test_get_imports_raises_when_non_solidity_files(compiler, vyper_source_path)
 def test_get_import_remapping(compiler, project, config):
     import_remapping = compiler.get_import_remapping()
     assert import_remapping == {
-        "@remapping/contracts": ".cache/TestDependency/local",
-        "@remapping_2": ".cache/TestDependency/local",
         "@brownie": ".cache/BrownieDependency/local",
         "@dependency_remapping": ".cache/TestDependencyOfDependency/local",
+        "@remapping_2": ".cache/TestDependency/local",
+        "@remapping/contracts": ".cache/TestDependency/local",
+        "@styleofbrownie": ".cache/BrownieStyleDependency/local",
     }
 
     with config.using_project(project.path / "ProjectWithinProject") as proj:
@@ -191,7 +193,7 @@ def test_get_version_map(project, compiler):
     assert all([f in version_map[expected_version] for f in file_paths[:-1]])
 
     latest_version_sources = version_map[latest_version]
-    assert len(latest_version_sources) == 8, "Did the import remappings load correctly?"
+    assert len(latest_version_sources) == 9, "Did the import remappings load correctly?"
     assert file_paths[-1] in latest_version_sources
 
     # Will fail if the import remappings have not loaded yet.
@@ -234,10 +236,11 @@ def test_compiler_data_in_manifest(project):
 
     common_suffix = ".cache/TestDependency/local"
     expected_remappings = (
-        f"@remapping/contracts={common_suffix}",
-        f"@remapping_2={common_suffix}",
         "@brownie=.cache/BrownieDependency/local",
         "@dependency_remapping=.cache/TestDependencyOfDependency/local",
+        f"@remapping_2={common_suffix}",
+        f"@remapping/contracts={common_suffix}",
+        "@styleofbrownie=.cache/BrownieStyleDependency/local",
     )
     actual_remappings = compiler_latest.settings["remappings"]
     assert all(x in actual_remappings for x in expected_remappings)
@@ -283,6 +286,7 @@ def test_get_versions(compiler, project):
         "0.6.12",
         "0.4.26",
         "0.5.16",
+        "0.7.6",
         "0.8.12",
     }
 
@@ -298,10 +302,11 @@ def test_get_compiler_settings(compiler, project):
     v812 = Version("0.8.12+commit.f00d7308")
     v817 = Version("0.8.17+commit.8df45f5f")
     expected_remappings = (
-        "@remapping/contracts=.cache/TestDependency/local",
         "@brownie=.cache/BrownieDependency/local",
         "@dependency_remapping=.cache/TestDependencyOfDependency/local",
         "@remapping_2=.cache/TestDependency/local",
+        "@remapping/contracts=.cache/TestDependency/local",
+        "@styleofbrownie=.cache/BrownieStyleDependency/local",
     )
     expected_v812_contracts = (source_a, source_b, source_c, indirect_source)
     expected_v817_contracts = (

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -286,7 +286,6 @@ def test_get_versions(compiler, project):
         "0.6.12",
         "0.4.26",
         "0.5.16",
-        "0.7.6",
         "0.8.12",
     }
 


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->
fixes: #
Goes with https://github.com/ApeWorX/ape/pull/1152

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
