### PR TITLE
test: use correct OpenZeppelin version in test project dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 *.swp
+tests/BrownieProject/ape-config.yaml
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/tests/BrownieProject/ape-config.yaml
+++ b/tests/BrownieProject/ape-config.yaml
@@ -1,9 +1,0 @@
-contracts_folder: contracts
-dependencies:
-- github: OpenZeppelin/openzeppelin-contracts
-  name: OpenZeppelin
-  version: 4.8.0
-solidity:
-  import_remapping:
-  - '@openzeppelin/contracts=OpenZeppelin/4.8.0'
-  version: 0.8.12

--- a/tests/BrownieProject/ape-config.yaml
+++ b/tests/BrownieProject/ape-config.yaml
@@ -2,8 +2,8 @@ contracts_folder: contracts
 dependencies:
 - github: OpenZeppelin/openzeppelin-contracts
   name: OpenZeppelin
-  version: 3.1.0
+  version: 4.8.0
 solidity:
   import_remapping:
-  - '@openzeppelin/contracts=OpenZeppelin/3.1.0'
+  - '@openzeppelin/contracts=OpenZeppelin/4.8.0'
   version: 0.8.12

--- a/tests/BrownieProject/brownie-config.yaml
+++ b/tests/BrownieProject/brownie-config.yaml
@@ -1,8 +1,8 @@
 dependencies:
-  - OpenZeppelin/openzeppelin-contracts@3.1.0
+  - OpenZeppelin/openzeppelin-contracts@4.5.0
 
 compiler:
   solc:
     version: 0.8.12
     remappings:
-      - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@3.1.0"
+      - "@openzeppelin=OpenZeppelin/openzeppelin-contracts@4.5.0"

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -35,7 +35,8 @@ DEFAULT_OPTIMIZER = {"enabled": True, "runs": 200}
 
 
 @pytest.mark.parametrize(
-    "contract", [c for c in TEST_CONTRACTS if all(n not in str(c) for n in normal_test_skips)]
+    "contract",
+    [c for c in TEST_CONTRACTS if all(n not in str(c) for n in normal_test_skips)],
 )
 def test_compile(project, contract):
     assert contract in project.contracts, ", ".join([n for n in project.contracts.keys()])

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -147,9 +147,16 @@ def test_get_import_remapping(compiler, project, config):
 
 
 def test_brownie_project(compiler, config):
+    from ape import project
+
+    _ = project.contracts
+
     brownie_project_path = Path(__file__).parent / "BrownieProject"
     with config.using_project(brownie_project_path) as project:
         assert type(project.BrownieContract) == ContractContainer
+
+        # Ensure can access twice (to make sure caching does not break anything).
+        _ = project.BrownieContract
 
 
 def test_compile_single_source_with_no_imports(compiler, config):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -147,10 +147,6 @@ def test_get_import_remapping(compiler, project, config):
 
 
 def test_brownie_project(compiler, config):
-    from ape import project
-
-    _ = project.contracts
-
     brownie_project_path = Path(__file__).parent / "BrownieProject"
     with config.using_project(brownie_project_path) as project:
         assert type(project.BrownieContract) == ContractContainer

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -231,8 +231,12 @@ def test_compiler_data_in_manifest(project):
         assert compiler.settings["evmVersion"] == "constantinople"
 
     # No remappings for sources in the following compilers
-    assert "remappings" not in compiler_0812.settings
-    assert "remappings" not in compiler_0612.settings
+    assert (
+        "remappings" not in compiler_0812.settings
+    ), f"Remappings found: {compiler_0812.settings['remappings']}"
+    assert (
+        "remappings" not in compiler_0612.settings
+    ), f"Remappings found: {compiler_0612.settings['remappings']}"
 
     common_suffix = ".cache/TestDependency/local"
     expected_remappings = (

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -25,7 +25,12 @@ def test_compile_using_cli(ape_cli, runner):
 
 @pytest.mark.parametrize(
     "contract_path",
-    ("CompilesOnce", "CompilesOnce.sol", "contracts/CompilesOnce", "contracts/CompilesOnce.sol"),
+    (
+        "CompilesOnce",
+        "CompilesOnce.sol",
+        "contracts/CompilesOnce",
+        "contracts/CompilesOnce.sol",
+    ),
 )
 def test_compile_specified_contracts(ape_cli, runner, contract_path):
     result = runner.invoke(ape_cli, ["compile", contract_path, "--force"], catch_exceptions=False)


### PR DESCRIPTION
### What I did

Uses OZ with version aligning with source files in the brownie-project dependency in the tests.
This was causing a test error, somehow didn't before.
**NOTE**: an ape release is required to get passing tests in CI because of https://github.com/ApeWorX/ape/pull/1194

### How I did it

* Noticed settings for 0.6 version had remapping when shouldn't
* Looked into it
* Realized the brownie project had an OZ dependency in the 0.6 range while its sources were in the 0.8 range
* Bumped OZ version in config

### How to verify it

Passing tests

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
