### PR TITLE
feat: add `sourcemap` to `ContractType` output

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -259,6 +259,7 @@ class SolidityCompiler(CompilerAPI):
                 "bin-runtime",
                 "devdoc",
                 "userdoc",
+                "srcmap",
             ],
             "optimize": self.config.optimize,
             "evm_version": self.config.evm_version,
@@ -372,6 +373,7 @@ class SolidityCompiler(CompilerAPI):
                 contract_type["runtimeBytecode"] = {"bytecode": runtime_bytecode}
                 contract_type["userdoc"] = load_dict(contract_type["userdoc"])
                 contract_type["devdoc"] = load_dict(contract_type["devdoc"])
+                contract_type["sourcemap"] = contract_type["srcmap"]
                 contract_type_obj = ContractType.parse_obj(contract_type)
                 contract_types.append(contract_type_obj)
                 solc_versions_by_contract_name[contract_name] = solc_version

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -299,13 +299,7 @@ def test_get_versions(compiler, project):
 
     # The "latest" version will always be in this list, but avoid
     # asserting on it directly to handle new "latest"'s coming out.
-    expected = (
-        "0.4.26",
-        "0.5.16",
-        "0.6.12",
-        "0.8.12",
-        "0.8.14",
-    )
+    expected = ("0.4.26", "0.5.16", "0.6.12", "0.8.12", "0.8.14")
     assert all([e in versions for e in expected])
 
 


### PR DESCRIPTION
### What I did

* Add and use `srcmap` output.

This stemmed from using Solidity docs to understand Vyper more, regarding `sourcemap`. However, I wanted to see this part work in Solidity to cross-compare and follow the docs. This is mostly part of my research into building coverage features in Ape.

Question: not sure we would want to merge this until we know we will be using this? That is fine if that is the case. I am mostly focused on Vyper right now, as is the plan.

fixes: APE-582

### How I did it

Found the output `srcmap` that gives the source map similarly to `pc_pos_map_compressed` in Vyper.

Is this correct?

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
