### PR TITLE
fix: issue causing wrong remapping to get used

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -477,7 +477,7 @@ class SolidityCompiler(CompilerAPI):
                 return source_id_value
 
             # Convert remapping list back to source using longest match (most exact).
-            key, value = max(matches, key=lambda x: x[0])
+            key, value = max(matches, key=lambda x: len(x[0]))
             sections = [s for s in source_id_value.split(key) if s]
             depth = len(sections) - 1
             source_id_value = ""

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -465,26 +465,32 @@ class SolidityCompiler(CompilerAPI):
             path = (source_path.parent / import_str_value).resolve()
             source_id_value = str(get_relative_path(path, contracts_path))
 
-            # Convert remapping list back to source
+            # Get all matches.
+            matches: List[Tuple[str, str]] = []
             for key, value in import_remapping.items():
                 if key not in source_id_value:
                     continue
 
-                sections = [s for s in source_id_value.split(key) if s]
-                depth = len(sections) - 1
-                source_id_value = ""
+                matches.append((key, value))
 
-                index = 0
-                for section in sections:
-                    if index == depth:
-                        source_id_value += value
-                        source_id_value += section
-                    elif index >= depth:
-                        source_id_value += section
+            if not matches:
+                return source_id_value
 
-                    index += 1
+            # Convert remapping list back to source using longest match (most exact).
+            key, value = max(matches, key=lambda x: x[0])
+            sections = [s for s in source_id_value.split(key) if s]
+            depth = len(sections) - 1
+            source_id_value = ""
 
-                break
+            index = 0
+            for section in sections:
+                if index == depth:
+                    source_id_value += value
+                    source_id_value += section
+                elif index >= depth:
+                    source_id_value += section
+
+                index += 1
 
             return source_id_value
 

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "py-solc-x>=1.1.0,<2",
-        "eth-ape>=0.6.0,<0.7",
+        "eth-ape>=0.6.4,<0.7",
         "ethpm-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -21,7 +21,7 @@ solidity:
   import_remapping:
     - "@remapping/contracts=TestDependency"
     - "@remapping_2=TestDependency"
-    - "@brownie=BrownieDependency"
+    - "@remapping_2_brownie=BrownieDependency"
 
     # Remapping for showing we can import a contract type from a brownie-style dependency
     # (provided the _single_ contract type compiles in the project).

--- a/tests/contracts/Imports.sol
+++ b/tests/contracts/Imports.sol
@@ -8,7 +8,7 @@ import
 import { MyStruct } from "CompilesOnce.sol";
 import "./subfolder/Relativecontract.sol";
 import "@remapping_2/Dependency.sol" as Depend2;
-import "@brownie/BrownieContract.sol";
+import "@remapping_2_brownie/BrownieContract.sol";
 import {
     Struct0,
     Struct1,

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -135,7 +135,7 @@ def test_get_imports_raises_when_non_solidity_files(compiler, vyper_source_path)
 def test_get_import_remapping(compiler, project, config):
     import_remapping = compiler.get_import_remapping()
     assert import_remapping == {
-        "@brownie": ".cache/BrownieDependency/local",
+        "@remapping_2_brownie": ".cache/BrownieDependency/local",
         "@dependency_remapping": ".cache/TestDependencyOfDependency/local",
         "@remapping_2": ".cache/TestDependency/local",
         "@remapping/contracts": ".cache/TestDependency/local",
@@ -255,7 +255,7 @@ def test_compiler_data_in_manifest(project):
     assert "@vault=.cache/vault/v0.4.5" in compiler_latest.settings["remappings"]
     common_suffix = ".cache/TestDependency/local"
     expected_remappings = (
-        "@brownie=.cache/BrownieDependency/local",
+        "@remapping_2_brownie=.cache/BrownieDependency/local",
         "@dependency_remapping=.cache/TestDependencyOfDependency/local",
         f"@remapping_2={common_suffix}",
         f"@remapping/contracts={common_suffix}",
@@ -319,7 +319,7 @@ def test_get_compiler_settings(compiler, project):
     v812 = Version("0.8.12+commit.f00d7308")
     latest = max(list(actual.keys()))
     expected_remappings = (
-        "@brownie=.cache/BrownieDependency/local",
+        "@remapping_2_brownie=.cache/BrownieDependency/local",
         "@dependency_remapping=.cache/TestDependencyOfDependency/local",
         "@remapping_2=.cache/TestDependency/local",
         "@remapping/contracts=.cache/TestDependency/local",


### PR DESCRIPTION
### What I did

fixes https://github.com/ApeWorX/ape/issues/1329
Fixes: APE-688

### How I did it

The early `break` in `get_imports` was the problem
Now, it grabs the most exact match.

### How to verify it

can put remappings in any order now.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
