### PR TITLE
feat: `enrich_error()` implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
       - id: isort
 
 -   repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
         name: black

--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ extras_require = {
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [
-        "black>=22.12.0",  # auto-formatter and linter
-        "mypy>=0.991",  # Static type analyzer
+        "black>=23.3.0",  # auto-formatter and linter
+        "mypy>=0.991,<1",  # Static type analyzer
         "types-requests",  # Needed due to mypy typeshed
         "types-setuptools",  # Needed due to mypy typeshed
         "flake8>=5.0.4",  # Style linter

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,8 @@ from tempfile import mkdtemp
 import ape
 import pytest
 import solcx  # type: ignore
+from ape.exceptions import ContractLogicError
+from ape_ethereum.transactions import DynamicFeeTransaction
 
 from ape_solidity.compiler import Extension
 
@@ -113,3 +115,27 @@ def account():
 def connection():
     with ape.networks.ethereum.local.use_provider("test"):
         yield
+
+
+@pytest.fixture
+def contract_logic_error():
+    txn_data = {
+        "chainId": 131277322940537,
+        "to": "0x274b028b03A250cA03644E6c578D81f019eE1323",
+        "from": "0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7",
+        "gas": 30029122,
+        "nonce": 0,
+        "value": 0,
+        "data": b"<\xcf\xd6\x0b",
+        "type": 2,
+        "maxFeePerGas": 875000000,
+        "maxPriorityFeePerGas": 0,
+        "accessList": [],
+    }
+    txn = DynamicFeeTransaction.parse_obj(txn_data)
+    message = (
+        "0xda472023"  # Unauthorized
+        "000000000000000000000000c89d42189f0450c2b2c3c61f58ec5d628176a1e7"  # addr
+        "000000000000000000000000000000000000000000000000000000000000007b"  # counter
+    )
+    return ContractLogicError(message, txn=txn)

--- a/tests/contracts/HasError.sol
+++ b/tests/contracts/HasError.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.4;
+
+error Unauthorized(address addr, uint256 counter);
+
+contract HasError {
+    address payable owner = payable(msg.sender);
+
+    function withdraw() public {
+        if (msg.sender != owner)
+            revert Unauthorized(msg.sender, 123);
+
+        owner.transfer(address(this).balance);
+    }
+    // ...
+}


### PR DESCRIPTION
### What I did

Goes with https://github.com/ApeWorX/ape/pull/1378

Now you get fun errors like:

```
  File "/Users/jules/ApeProjects/ape-playground/scripts/haserror.py", line 8, in main
    contract.withdraw(sender=other)

ERROR: (Unauthorized) addr=0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7, counter=123
```

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
