### PR TITLE
fix: added path normalization of ImportRemapping.name

### DIFF
--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -38,13 +38,15 @@ class ImportRemapping(BaseModel):
     def _parts(self) -> List[str]:
         return self.entry.split("=")
 
+    # path normalization needed in case delimiter in remapping key/value
+    # and system path delimiter are different (Windows as an example)
     @property
     def key(self) -> str:
-        return self._parts[0]
+        return os.path.normpath(self._parts[0])
 
     @property
     def name(self) -> str:
-        suffix_str = self._parts[1]
+        suffix_str = os.path.normpath(self._parts[1])
         return suffix_str.split(os.path.sep)[0]
 
     @property
@@ -91,9 +93,7 @@ class ImportRemappingBuilder:
         if not str(path).startswith(f".cache{os.path.sep}"):
             path = Path(".cache") / path
 
-        # path normalization needed in case delimiter in remapping key and
-        # system path delimiter are different (Windows as an example)
-        self.import_map[os.path.normpath(remapping.key)] = str(path)
+        self.import_map[remapping.key] = str(path)
 
 
 def get_import_lines(source_paths: Set[Path]) -> Dict[Path, List[str]]:


### PR DESCRIPTION
 to match with `os.path.sep` in splitting suffix, moved key normalization to `ImportRemapping.key` method

### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

`ImportRemapping.name` uses `os.path.sep` to get suffix of package. In case different delimiters this split won't work.
Also normalization of key moved from `ImportRemappingBuilder` to `ImportRemapping` to have them in the same place.

fixes: #

### How I did it

Before splitting - path normalized and `os.path.sep` will work on any system.

### How to verify it

Clean compile on Windows or using different slashes in remmaping.
With this commmit and ApeWorX/ape#1388 I'm able to make clean compile and run tests on Windows: download dependencies, extract manifest, prepare .cache folder and prepare command line with proper remmapings.

### Checklist

- [X] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
