### PR TITLE
fix: Convert content object to string when writing to cached source. [APE-954]

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -199,7 +199,7 @@ class SolidityCompiler(CompilerAPI):
             cached_source.parent.mkdir(parents=True, exist_ok=True)
             if src.content:
                 cached_source.touch()
-                cached_source.write_text(src.content or "")
+                cached_source.write_text(str(src.content) or "")
 
         # Add dependency remapping that may be needed.
         for compiler in manifest.compilers or []:


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

Issue observed was:

```
  File "/Users/derek/.local/share/virtualenvs/nucypher-contracts-mlay0-TM/lib/python3.8/site-packages/ape_solidity/compiler.py", line 521, in get_version_map
    _ = self.get_import_remapping(base_path=base_path)
  File "/Users/derek/.local/share/virtualenvs/nucypher-contracts-mlay0-TM/lib/python3.8/site-packages/ape_solidity/compiler.py", line 175, in get_import_remapping
    self._add_dependencies(manifest, sub_contracts_cache, builder)
  File "/Users/derek/.local/share/virtualenvs/nucypher-contracts-mlay0-TM/lib/python3.8/site-packages/ape_solidity/compiler.py", line 202, in _add_dependencies
    cached_source.write_text(src.content or "")
  File "/opt/homebrew/opt/python@3.8/Frameworks/Python.framework/Versions/3.8/lib/python3.8/pathlib.py", line 1253, in write_text
    raise TypeError('data must be str, not %s' %
TypeError: data must be str, not Content

ERROR: Unable to load project. Failure reason: (TypeError) data must be str, not Content
```

fixes: #

### How I did it


### How to verify it

Try compiling a contract with ape that has a github dependency. I used it here - https://github.com/nucypher/nucypher-contracts/pull/81. See https://github.com/nucypher/nucypher-contracts/pull/81/commits/ea9658f9e7d09ab4145e920c071b0f9d79148c6a.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
