### PR TITLE
fix: adding depency crashes when not string [APE-959]

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -200,7 +200,7 @@ class SolidityCompiler(CompilerAPI):
             if src.content:
                 cached_source.touch()
                 cached_source.write_text(
-                    src.content if isinstance(src.content, str) else f"{src.content}"
+                    src.content if isinstance(src.content, str) else str(src.content)
                 )
 
         # Add dependency remapping that may be needed.

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -199,7 +199,9 @@ class SolidityCompiler(CompilerAPI):
             cached_source.parent.mkdir(parents=True, exist_ok=True)
             if src.content:
                 cached_source.touch()
-                cached_source.write_text(src.content if isinstance(src.content, str) else f"{src.content}")
+                cached_source.write_text(
+                    src.content if isinstance(src.content, str) else f"{src.content}"
+                )
 
         # Add dependency remapping that may be needed.
         for compiler in manifest.compilers or []:

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -199,7 +199,7 @@ class SolidityCompiler(CompilerAPI):
             cached_source.parent.mkdir(parents=True, exist_ok=True)
             if src.content:
                 cached_source.touch()
-                cached_source.write_text(src.content or "")
+                cached_source.write_text(src.content if isinstance(src.content, str) else f"{src.content}")
 
         # Add dependency remapping that may be needed.
         for compiler in manifest.compilers or []:


### PR DESCRIPTION
### What I did

make sure write_test receives a string input.

fixes: #

### How I did it

converting only when needed, using an f-string.

### How to verify it

see [PR in my branch](https://github.com/wakamex/ape-solidity/pull/2) that reverts the fix. lots of tests fail without the fix. functional tests pass with the fix:
![image](https://github.com/ApeWorX/ape-solidity/assets/16990562/72022b7d-4bb2-4abf-b845-f6ab06474057)

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
