### PR TITLE
feat: AST nodes [APE-967]

### DIFF
--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -20,7 +20,6 @@ from ape_solidity.exceptions import IncorrectMappingFormatError
 
 OUTPUT_SELECTION = [
     "abi",
-    "ast",
     "bin-runtime",
     "devdoc",
     "userdoc",

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     install_requires=[
         "py-solc-x>=1.1.0,<2",
         "eth-ape>=0.6.9,<0.7",
-        "ethpm-types",  # Use the version ape requires
+        "ethpm-types>=0.5.1,<0.6",  # Currently bumped 1 higher than eth-ape's.
         "packaging",  # Use the version ape requires
         "requests",
     ],

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "py-solc-x>=1.1.0,<2",
-        "eth-ape>=0.6.8,<0.7",
+        "eth-ape>=0.6.9,<0.7",
         "ethpm-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(
         "ethpm-types>=0.5.1,<0.6",  # Currently bumped 1 higher than eth-ape's.
         "packaging",  # Use the version ape requires
         "requests",
+        "typing-extensions==4.5.0"  # Can be removed onced pinned in Core.
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
         "ethpm-types>=0.5.1,<0.6",  # Currently bumped 1 higher than eth-ape's.
         "packaging",  # Use the version ape requires
         "requests",
-        "typing-extensions==4.5.0"  # Can be removed onced pinned in Core.
+        "typing-extensions==4.5.0",  # Can be removed onced pinned in Core.
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
### What I did

* Get AST data and create objects from ethpm-types for each contract type

### How I did it

For the input JSON, you have to put `"ast"` at the source level; not the contract level, for it to work.
**This means Ape is slightly bloated in that will have duplicate AST info when contracts are stored in the same file.**

this will be needed for contract flattening (i think, based on looking at past implementation), that is why i added it

### How to verify it

Can now play with the AST node in contracts.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
