### PR TITLE
feat: Add viaIR, runs to config settings [APE-1013]

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -45,6 +45,8 @@ class SolidityConfig(PluginConfig):
     # e.g. '@import_name=path/to/dependency'
     import_remapping: List[str] = []
     optimize: bool = True
+    runs: int = 200
+    via_ir: bool = False
     version: Optional[str] = None
     evm_version: Optional[str] = None
 
@@ -289,11 +291,12 @@ class SolidityCompiler(CompilerAPI):
         settings: Dict = {}
         for solc_version, sources in files_by_solc_version.items():
             version_settings: Dict[str, Union[Any, List[Any]]] = {
-                "optimizer": {"enabled": self.config.optimize, "runs": 200},
+                "optimizer": {"enabled": self.config.optimize, "runs": self.config.runs},
                 "outputSelection": {
                     str(get_relative_path(p, base_path)): {"*": OUTPUT_SELECTION, "": ["ast"]}
                     for p in sources
                 },
+                "viaIR": self.config.via_ir,
             }
             remappings_used = set()
             if import_remappings:

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -296,8 +296,11 @@ class SolidityCompiler(CompilerAPI):
                     str(get_relative_path(p, base_path)): {"*": OUTPUT_SELECTION, "": ["ast"]}
                     for p in sources
                 },
-                "viaIR": self.config.via_ir,
             }
+
+            if solc_version >= Version("0.7.5"):
+                version_settings["viaIR"] = self.config.via_ir
+
             remappings_used = set()
             if import_remappings:
                 # Filter out unused import remapping


### PR DESCRIPTION
### What I did

Allows ape users to specify `via_ir`, `runs` params in `ape-config.yaml` to use with the Solidity compiler.

Fixes: #67, #94 

### How I did it

Added `runs`, `via_ir` to `SolidityConfig`. 

### How to verify it

e.g. in any `ape-config.yaml`

```
solidity:
  runs: 800
  via_ir: true
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
