### PR TITLE
feat: python 3.11 support [APE-1038]

### DIFF
--- a/.github/workflows/prtitle.yaml
+++ b/.github/workflows/prtitle.yaml
@@ -17,7 +17,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: pip install commitizen

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.10"
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: |
@@ -47,7 +47,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: "3.10"
 
         - name: Install Dependencies
           run: |
@@ -63,7 +63,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.8, 3.9, '3.10']
+                python-version: [3.8, 3.9, '3.10', '3.11']
 
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -97,7 +97,7 @@ jobs:
     #     - name: Setup Python
     #       uses: actions/setup-python@v4
     #       with:
-    #           python-version: 3.8
+    #           python-version: "3.10"
 
     #     - name: Install Dependencies
     #       run: pip install .[test]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Compile Solidity contracts.
 
 ## Dependencies
 
-- [python3](https://www.python.org/downloads) version 3.8 or greater, python3-dev
+- [python3](https://www.python.org/downloads) version 3.8 up to 3.11, python3-dev
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Compile Solidity contracts.
 
 ## Dependencies
 
-- [python3](https://www.python.org/downloads) version 3.8 up to 3.11, python3-dev
+- [python3](https://www.python.org/downloads) version 3.8 up to 3.11.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ write_to = "ape_solidity/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310', 'py311']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -91,5 +91,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     install_requires=[
         "py-solc-x>=1.1.0,<2",
         "eth-ape>=0.6.9,<0.7",
-        "ethpm-types>=0.5.1,<0.6",  # Currently bumped 1 higher than eth-ape's.
+        "ethpm-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",
         "typing-extensions==4.5.0",  # Can be removed onced pinned in Core.


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #
Fixes: APE-994

### How I did it

- change default from 3.8 to 3.10
- update setup.py project tag and supported versions tag
- update readme

### How to verify it

- everything works the same on 3.11

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
