### PR TITLE
fix: handle when no contracts in file [APE-1135]

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -378,8 +378,9 @@ class SolidityCompiler(CompilerAPI):
             except SolcError as err:
                 raise CompilerError(str(err)) from err
 
+            contracts = output.get("contracts", {})
             input_contract_names: List[str] = []
-            for source_id, contracts_out in output["contracts"].items():
+            for source_id, contracts_out in contracts.items():
                 for name, _ in contracts_out.items():
                     # Filter source files that the user did not ask for, such as
                     # imported relative files that are not part of the input.
@@ -394,7 +395,7 @@ class SolidityCompiler(CompilerAPI):
                 for child in _node.children:
                     classify_ast(child)
 
-            for source_id, contracts_out in output["contracts"].items():
+            for source_id, contracts_out in contracts.items():
                 ast_data = output["sources"][source_id]["ast"]
                 ast = ASTNode.parse_obj(ast_data)
                 classify_ast(ast)

--- a/tests/contracts/JustAStruct.sol
+++ b/tests/contracts/JustAStruct.sol
@@ -1,0 +1,3 @@
+struct Data {
+    mapping(uint => bool) flags;
+}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -30,6 +30,7 @@ normal_test_skips = (
     "MultipleDefinitions",
     "RandomVyperFile",
     "LibraryFun",
+    "JustAStruct",
 )
 raises_because_not_sol = pytest.raises(CompilerError, match=EXPECTED_NON_SOLIDITY_ERR_MSG)
 DEFAULT_OPTIMIZER = {"enabled": True, "runs": 200}

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -102,6 +102,15 @@ def test_compile_vyper_contract(compiler, vyper_source_path):
         compiler.compile([vyper_source_path])
 
 
+def test_compile_just_a_struct(compiler, project):
+    """
+    Before you would get a nasty index error, even though this valid Solidity.
+    The fix involved using nicer access to `"contracts"` in the standard output JSON.
+    """
+    contract_types = compiler.compile([project.contracts_folder / "JustAStruct.sol"])
+    assert len(contract_types) == 0
+
+
 def test_get_imports(project, compiler):
     import_dict = compiler.get_imports(TEST_CONTRACT_PATHS, BASE_PATH)
     contract_imports = import_dict["Imports.sol"]

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -104,8 +104,8 @@ def test_compile_vyper_contract(compiler, vyper_source_path):
 
 def test_compile_just_a_struct(compiler, project):
     """
-    Before you would get a nasty index error, even though this valid Solidity.
-    The fix involved using nicer access to `"contracts"` in the standard output JSON.
+    Before, you would get a nasty index error, even though this is valid Solidity.
+    The fix involved using nicer access to "contracts" in the standard output JSON.
     """
     contract_types = compiler.compile([project.contracts_folder / "JustAStruct.sol"])
     assert len(contract_types) == 0


### PR DESCRIPTION
### What I did

noticed it failed when compiling a project with only a struct in it (the project also was using dependencies)

### How I did it

`.get()`

### How to verify it

when compiling only a sol file with no contracts in it, it does not barf out

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
