### PR TITLE
feat: way nicer error when typing an import statement wrong [APE-1152]

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -356,6 +356,12 @@ class SolidityCompiler(CompilerAPI):
             if solc_version >= Version("0.6.9"):
                 arguments["base_path"] = base_path
 
+            if missing_sources := [
+                x for x in vers_settings["outputSelection"] if not (base_path / x).is_file()
+            ]:
+                missing_src_str = ", ".join(missing_sources)
+                raise CompilerError(f"Missing sources: '{missing_src_str}'.")
+
             sources = {
                 x: {"content": (base_path / x).read_text()}
                 for x in vers_settings["outputSelection"]


### PR DESCRIPTION
### What I did

Better error when you type an import wrong and stuff, like this:

```solidity
import "@openzeppelin/contracts/proxy/beacon/IdBeacon.sol";
```

see, i spelled it wrong, and it failed with `FileNotFoundError` which wasn't bad but was kinda unexpected.
If I let it slide to the compiler, the message was really nasty tho.

So here i made it ideal

### How I did it

check for missing files and raise a nice pretty message if you find any.

### How to verify it

see my sol example at top

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
