### PR TITLE
feat: airplane mode (non-exact compiler version match) [APE-1161]

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -673,17 +673,17 @@ class SolidityCompiler(CompilerAPI):
             install_solc(compiler_version, show_progress=False)
         else:
             # Attempt to use the best-installed version.
-            # NOTE: Use the oldest version available for maximum compatibility.
-            for version in reversed(self.installed_versions):
-                if pragma_spec.match(version):
-                    logger.warning(
-                        "The installed version(s) are not ideal, "
-                        "and Ape is unable to install additional versions. "
-                        "Resorting to the best matching already-installed version. "
-                        "Alternatively, specify a Solidity compiler version in your "
-                        "ape-config.yaml."
-                    )
-                    return pragma_spec
+            for version in self.installed_versions:
+                if not pragma_spec.match(version):
+                    continue
+
+                logger.warning(
+                    "The installed version(s) are not ideal, and Ape is unable "
+                    "to install additional versions. Resorting to the best matching "
+                    "already-installed version. Alternatively, specify a Solidity "
+                    "compiler version in your ape-config.yaml."
+                )
+                return pragma_spec
 
             # None of the installed versions match, and we are unable to install.
             raise CompilerError(f"Solidity version specification '{pragma_spec}' could not be met.")

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -678,8 +678,8 @@ class SolidityCompiler(CompilerAPI):
                     continue
 
                 logger.warning(
-                    "The installed version(s) are not ideal, and Ape is unable "
-                    "to install additional versions. Resorting to the best matching "
+                    "Ape is unable to determine if additional versions are needed "
+                    f"in order to meet spec {pragma_spec}. Resorting to the best matching "
                     "already-installed version. Alternatively, specify a Solidity "
                     "compiler version in your ape-config.yaml."
                 )

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -674,7 +674,7 @@ class SolidityCompiler(CompilerAPI):
         else:
             # Attempt to use the best-installed version.
             # NOTE: Use the oldest version available for maximum compatibility.
-            for version in self.installed_versions[::-1]:
+            for version in reversed(self.installed_versions):
                 if pragma_spec.match(version):
                     logger.warning(
                         "The installed version(s) are not ideal, "

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -652,8 +652,11 @@ class SolidityCompiler(CompilerAPI):
             return None
 
         # Check if we need to install specified compiler version
-        if pragma_spec is pragma_spec.select(self.installed_versions):
-            return pragma_spec
+        # match with oldest version available for maximum compatibility
+        for version in self.installed_versions[::-1]:
+            if pragma_spec.match(version):
+                logger.debug("compiling %s (%s) with %s", path, pragma_spec, version)
+                return pragma_spec
 
         compiler_version = pragma_spec.select(self.available_versions)
         if compiler_version:

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ extras_require = {
         "pytest>=6.0",  # Core testing package
         "pytest-xdist",  # multi-process runner
         "pytest-cov",  # Coverage analyzer plugin
+        "pytest-mock",  # For creating and using mocks
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
     ],
     "lint": [

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -108,7 +108,7 @@ def test_get_imports(project, compiler):
     # NOTE: make sure there aren't duplicates
     assert len([x for x in contract_imports if contract_imports.count(x) > 1]) == 0
     # NOTE: returning a list
-    assert type(contract_imports) == list
+    assert type(contract_imports) is list
     # NOTE: in case order changes
     expected = {
         ".cache/BrownieDependency/local/BrownieContract.sol",
@@ -155,7 +155,7 @@ def test_get_import_remapping(compiler, project, config):
 def test_brownie_project(compiler, config):
     brownie_project_path = Path(__file__).parent / "BrownieProject"
     with config.using_project(brownie_project_path) as project:
-        assert type(project.BrownieContract) == ContractContainer
+        assert type(project.BrownieContract) is ContractContainer
 
         # Ensure can access twice (to make sure caching does not break anything).
         _ = project.BrownieContract
@@ -166,7 +166,7 @@ def test_compile_single_source_with_no_imports(compiler, config):
     # where the source file was individually compiled and it had no imports.
     path = Path(__file__).parent / "DependencyOfDependency"
     with config.using_project(path) as project:
-        assert type(project.DependencyOfDependency) == ContractContainer
+        assert type(project.DependencyOfDependency) is ContractContainer
 
 
 def test_version_specified_in_config_file(compiler, config):


### PR DESCRIPTION
### What I did

make lazy compiler match

fixes: #

### How I did it

use the built-in `match` function of the pragma_spec to check if an existing (downloaded) solidity spec is a match, and if so use it. this avoids trying to download new solc versions very aggresively, which makes it impossible to compile using ape on an airplane.

### How to verify it

turn off your wifi and try to compile anything, without and with this PR.

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
