### PR TITLE
feat: enable via_ir in solidity settings [APE-1256]

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,12 @@ for compiler_entry in manifest.compilers:
 ```
 
 **NOTE**: These are the settings used during contract verification when using the [Etherscan plugin](https://github.com/ApeWorX/ape-etherscan).
+
+#### `--via-IR` Yul IR Compilation Pipeline
+
+You can enable `solc`'s `--via-IR` flag by adding the following values to your `ape-config.yaml`
+
+```yaml
+solidity:
+  via_ir: True
+```

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -47,6 +47,7 @@ class SolidityConfig(PluginConfig):
     optimize: bool = True
     version: Optional[str] = None
     evm_version: Optional[str] = None
+    via_ir: bool = False
 
 
 class SolidityCompiler(CompilerAPI):
@@ -318,6 +319,9 @@ class SolidityCompiler(CompilerAPI):
             evm_version = self.config.evm_version
             if evm_version:
                 version_settings["evmVersion"] = evm_version
+
+            if solc_version >= Version("0.7.5"):
+                version_settings["viaIR"] = self.config.via_ir
 
             settings[solc_version] = version_settings
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -501,6 +501,9 @@ contract StackTooDeep {
     # delete source code file
     os.remove(source_path)
 
+    # flip the via_ir flag back to False
+    compiler.config.via_ir = False
+
 
 def test_flatten(project, compiler, data_folder):
     source_path = project.contracts_folder / "Imports.sol"

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -486,8 +486,7 @@ contract StackTooDeep {
     """
 
     # write source code to file
-    with open(source_path, "w") as f:
-        f.write(source_code)
+   source_path.write_text(source_code)
 
     try:
         compiler.compile([source_path])

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -407,6 +407,7 @@ def test_ast(project, compiler):
     assert actual.ast_type == "SourceUnit"
     assert fn_node.classification == ASTClassification.FUNCTION
 
+
 def test_via_ir(project, compiler):
     source_path = project.contracts_folder / "StackTooDeep.sol"
     source_code = """

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -122,7 +122,7 @@ def test_get_imports(project, compiler):
     # NOTE: make sure there aren't duplicates
     assert len([x for x in contract_imports if contract_imports.count(x) > 1]) == 0
     # NOTE: returning a list
-    assert type(contract_imports) == list
+    assert isinstance(contract_imports, list)
     # NOTE: in case order changes
     expected = {
         ".cache/BrownieDependency/local/BrownieContract.sol",
@@ -171,7 +171,7 @@ def test_get_import_remapping(compiler, project, config):
 def test_brownie_project(compiler, config):
     brownie_project_path = Path(__file__).parent / "BrownieProject"
     with config.using_project(brownie_project_path) as project:
-        assert type(project.BrownieContract) == ContractContainer
+        assert isinstance(project.BrownieContract, ContractContainer)
 
         # Ensure can access twice (to make sure caching does not break anything).
         _ = project.BrownieContract
@@ -182,7 +182,7 @@ def test_compile_single_source_with_no_imports(compiler, config):
     # where the source file was individually compiled and it had no imports.
     path = Path(__file__).parent / "DependencyOfDependency"
     with config.using_project(path) as project:
-        assert type(project.DependencyOfDependency) == ContractContainer
+        assert isinstance(project.DependencyOfDependency, ContractContainer)
 
 
 def test_version_specified_in_config_file(compiler, config):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,5 +1,4 @@
 import json
-import os
 import re
 import shutil
 from pathlib import Path
@@ -486,7 +485,7 @@ contract StackTooDeep {
     """
 
     # write source code to file
-   source_path.write_text(source_code)
+    source_path.write_text(source_code)
 
     try:
         compiler.compile([source_path])

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -498,7 +498,7 @@ contract StackTooDeep {
     compiler.compile([source_path])
 
     # delete source code file
-    os.remove(source_path)
+    source_path.unlink()
 
     # flip the via_ir flag back to False
     compiler.config.via_ir = False


### PR DESCRIPTION
### What I did

Enable compiling contracts with the `--via-ir` solc flag

### How I did it

parse a boolean config value for enabling the `--via-ir` flag. this enables compiling solidity contracts through the Yul IR pipeline. This avoids `stack too deep` errors.

I wrote the affected contract as inline code because if I write it as a contract in the contracts folder, then we have to enable `via_ir` for the whole project, or else all tests fail when compilation is attempted

so I wrote it as inline source, write it to a file, attempt compilation without `via_ir` and check that it fails, and then re-attempt compilation after enabling the  `via_ir` flag.

### How to verify it

Add the following config values in a repo with contracts affected by stack-too-deep

```yaml
solidity:
    via_ir: True
```

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
