### PR TITLE
fix: take into account verbosity when showing SolcError

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -47,6 +47,7 @@ from ape_solidity.exceptions import (
     IncorrectMappingFormatError,
     RuntimeErrorType,
     RuntimeErrorUnion,
+    SolcCompileError,
     SolcInstallError,
 )
 
@@ -475,7 +476,7 @@ class SolidityCompiler(CompilerAPI):
             try:
                 output = compile_standard(input_json, **arguments)
             except SolcError as err:
-                raise CompilerError(str(err)) from err
+                raise SolcCompileError(err) from err
 
             contracts = output.get("contracts", {})
             input_contract_names: List[str] = []
@@ -592,7 +593,7 @@ class SolidityCompiler(CompilerAPI):
                 allow_empty=True,
             )
         except SolcError as err:
-            raise CompilerError(str(err)) from err
+            raise SolcCompileError(err) from err
 
         output = result[next(iter(result.keys()))]
         return ContractType(

--- a/ape_solidity/exceptions.py
+++ b/ape_solidity/exceptions.py
@@ -2,6 +2,8 @@ from enum import IntEnum
 from typing import Dict, Type, Union
 
 from ape.exceptions import CompilerError, ConfigError, ContractLogicError
+from ape.logging import LogLevel, logger
+from solcx.exceptions import SolcError
 
 
 class SolcInstallError(CompilerError):
@@ -14,6 +16,26 @@ class SolcInstallError(CompilerError):
         super().__init__(
             "No versions of `solc` installed and unable to install latest `solc` version."
         )
+
+
+class SolcCompileError(CompilerError):
+    """
+    Specifically, only errors arising from ``solc`` compile methods.
+    This error is a modified version of ``SolcError`` to take into
+    account Ape's logging verbosity.
+    """
+
+    def __init__(self, solc_error: SolcError):
+        self.solc_error = solc_error
+
+    def __str__(self) -> str:
+        if logger.level <= LogLevel.DEBUG:
+            # Show everything when in DEBUG mode.
+            return str(self.solc_error)
+
+        else:
+            # Only show the error and line-number(s) where it occurred.
+            return self.solc_error.message
 
 
 class IncorrectMappingFormatError(ConfigError, ValueError):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,44 @@
+import pytest
+from ape.logging import logger
+from solcx.exceptions import SolcError
+
+from ape_solidity.exceptions import SolcCompileError
+
+MESSAGE = "__message__"
+COMMAND = ["solc", "command"]
+RETURN_CODE = 123
+STDOUT_DATA = "<stdout data>"
+STDERR_DATA = "<stderr data>"
+
+
+@pytest.fixture(scope="module")
+def solc_error():
+    return SolcError(
+        message=MESSAGE,
+        command=COMMAND,
+        return_code=RETURN_CODE,
+        stdout_data=STDOUT_DATA,
+        stderr_data=STDERR_DATA,
+    )
+
+
+def test_solc_compile_error(solc_error):
+    error = SolcCompileError(solc_error)
+    actual = str(error)
+    assert MESSAGE in actual
+    assert f"{RETURN_CODE}" not in actual
+    assert " ".join(COMMAND) not in actual
+    assert STDOUT_DATA not in actual
+    assert STDERR_DATA not in actual
+
+
+def test_solc_compile_error_verbose(solc_error):
+    logger.set_level("DEBUG")
+    error = SolcCompileError(solc_error)
+    actual = str(error)
+    assert MESSAGE in actual
+    assert f"{RETURN_CODE}" in actual
+    assert " ".join(COMMAND) in actual
+    assert STDOUT_DATA in actual
+    assert STDERR_DATA in actual
+    logger.set_level("INFO")


### PR DESCRIPTION
### What I did

people said the SolcError was too verbose in some cases, so now it is less so (unless you are specifically looking for verbose errors)

### How I did it

Only show message if not verbose.
Else, show the full deal (like we were doing)

### How to verify it

```sh
ape compile  # less error
ape compile -v DEBUG   # more error
```

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
