### PR TITLE
chore: misses from 0.7 updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Use the `add_library()` method from the `ape-solidity` compiler class to add the
 A typical flow is:
 
 1. Deploy the library.
-1. Call `add_library()` using the Solidity compiler plugin, which will also re-compile contracts that need the library.
-1. Deploy and use contracts that require the library.
+2. Call `add_library()` using the Solidity compiler plugin, which will also re-compile contracts that need the library.
+3. Deploy and use contracts that require the library.
 
 For example:
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -455,7 +455,6 @@ class SolidityCompiler(CompilerAPI):
             if not list(files_by_solc_version[solc_version]):
                 continue
 
-            logger.debug(f"Compiling using Solidity compiler '{solc_version}'")
             cleaned_version = Version(solc_version.base_version)
             solc_binary = get_executable(version=cleaned_version)
             arguments = {"solc_binary": solc_binary, "solc_version": cleaned_version}

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ extras_require = {
         "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
+        "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml
     ],
     "doc": [
         "Sphinx>=6.1.3,<7",  # Documentation generator


### PR DESCRIPTION
### What I did

*missed mdformat dependency so that wasnt doing it right
*dang thing got double logged, made it seem like double compile but nooo

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
