### PR TITLE
perf: remove unused ASTNode parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ version.py
 *.swo
 
 tests/node_modules
+.benchmarks/

--- a/README.md
+++ b/README.md
@@ -97,8 +97,8 @@ Use the `add_library()` method from the `ape-solidity` compiler class to add the
 A typical flow is:
 
 1. Deploy the library.
-1. Call `add_library()` using the Solidity compiler plugin, which will also re-compile contracts that need the library.
-1. Deploy and use contracts that require the library.
+2. Call `add_library()` using the Solidity compiler plugin, which will also re-compile contracts that need the library.
+3. Deploy and use contracts that require the library.
 
 For example:
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ extras_require = {
         "pytest-cov",  # Coverage analyzer plugin
         "pytest-mock",  # For creating and using mocks
         "hypothesis>=6.2.0,<7.0",  # Strategy-based fuzzer
+        "pytest-benchmark",  # For performance tests
     ],
     "lint": [
         "black>=23.12.0,<24",  # Auto-formatter and linter
@@ -21,6 +22,7 @@ extras_require = {
         "mdformat>=0.7.17",  # Auto-formatter for markdown
         "mdformat-gfm>=0.3.5",  # Needed for formatting GitHub-flavored markdown
         "mdformat-frontmatter>=0.4.1",  # Needed for frontmatters-style headers in issue templates
+        "mdformat-pyproject>=0.0.1",  # Allows configuring in pyproject.toml
     ],
     "doc": [
         "Sphinx>=6.1.3,<7",  # Documentation generator

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -54,7 +54,7 @@ def test_compile_performance(benchmark, compiler, project):
     See https://pytest-benchmark.readthedocs.io/en/latest/
     """
     source_path = project.contracts_folder / "MultipleDefinitions.sol"
-    result = benchmark.pedantic(compiler.compile, args=[source_path], rounds=1)
+    result = benchmark.pedantic(compiler.compile, args=([source_path],), rounds=1)
     assert len(result) > 0
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -8,7 +8,6 @@ import solcx
 from ape import reverts
 from ape.contracts import ContractContainer
 from ape.exceptions import CompilerError
-from ethpm_types.ast import ASTClassification
 from packaging.version import Version
 from pkg_resources import get_distribution
 from requests.exceptions import ConnectionError
@@ -48,6 +47,15 @@ def test_compile(project, contract):
     assert contract in project.contracts, ", ".join([n for n in project.contracts.keys()])
     contract = project.contracts[contract]
     assert contract.source_id == f"{contract.name}.sol"
+
+
+def test_compile_performance(benchmark, compiler, project):
+    """
+    See https://pytest-benchmark.readthedocs.io/en/latest/
+    """
+    source_path = project.contracts_folder / "MultipleDefinitions.sol"
+    result = benchmark.pedantic(compiler.compile, args=[source_path], rounds=1)
+    assert len(result) > 0
 
 
 def test_compile_solc_not_installed(project, fake_no_installs):
@@ -477,12 +485,13 @@ def test_enrich_error_when_builtin(project, owner, connection):
         contract.checkIndexOutOfBounds(sender=owner)
 
 
-def test_ast(project, compiler):
-    source_path = project.contracts_folder / "MultipleDefinitions.sol"
-    actual = compiler.compile([source_path])[-1].ast
-    fn_node = actual.children[1].children[0]
-    assert actual.ast_type == "SourceUnit"
-    assert fn_node.classification == ASTClassification.FUNCTION
+# TODO: Not yet used and super slow.
+# def test_ast(project, compiler):
+#     source_path = project.contracts_folder / "MultipleDefinitions.sol"
+#     actual = compiler.compile([source_path])[-1].ast
+#     fn_node = actual.children[1].children[0]
+#     assert actual.ast_type == "SourceUnit"
+#     assert fn_node.classification == ASTClassification.FUNCTION
 
 
 def test_via_ir(project, compiler):


### PR DESCRIPTION
### What I did

<!-- The `fixes:` field denotes an issue that will be marked resolved by merging this PR -->

fixes: #https://github.com/ApeWorX/ape/issues/1726

### How I did it

* Del ASTNode logic for now as there are no tracing features yet in solidity so this does not affect anything and it was too pre-emptive to add anyway. I would like to get tracing features working and somehing like this is a first step, but the performance concerns leads me to think are going to probably want the raw dicts in the manifest instead and parse them later so compiling alone does not take forever, but will probably adjust `ape-vyper` like that first.

### How to verify it

With this PR:

```
(ape310) ➜  ape-playground git:(repro1726) ✗ time ape compile -f
INFO: Compiling 'token.sol'.
INFO: Compiling 'Lib.sol'.
INFO (ape-solidity): Compiling using Solidity compiler '0.8.23+commit.f704f362'.
ape compile -f  4.63s user 0.76s system 122% cpu 4.391 total
```

Without this PR:

```
(ape310) ➜  ape-playground git:(repro1726) ✗ time ape compile -f
INFO: Compiling 'token.sol'.
INFO: Compiling 'Lib.sol'.
INFO (ape-solidity): Compiling using Solidity compiler '0.8.23+commit.f704f362'.
ape compile -f  33.43s user 0.84s system 102% cpu 33.307 total
```

4.63 seconds with PR, 33.43 w

**That is 86.8% increase!**

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
