### PR TITLE
feat: support configured dependency cache directory

### DIFF
--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -102,7 +102,7 @@ class ImportRemappingBuilder:
 
     def add_entry(self, remapping: ImportRemapping):
         path = remapping.package_id
-        if str(self.contracts_cache) not in str(path):
+        if self.contracts_cache not in path.parents:
             path = self.contracts_cache / path
 
         self.import_map[remapping.key] = str(path)
@@ -110,7 +110,6 @@ class ImportRemappingBuilder:
 
 def get_import_lines(source_paths: Set[Path]) -> Dict[Path, List[str]]:
     imports_dict: Dict[Path, List[str]] = {}
-
     for filepath in source_paths:
         import_set = set()
         if not filepath.is_file():

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -95,15 +95,15 @@ class ImportRemapping(BaseModel):
 class ImportRemappingBuilder:
     def __init__(self, contracts_cache: Path):
         # import_map maps import keys like `@openzeppelin/contracts`
-        # to str paths in the contracts' .cache folder.
+        # to str paths in the compiler cache folder.
         self.import_map: Dict[str, str] = {}
         self.dependencies_added: Set[Path] = set()
         self.contracts_cache = contracts_cache
 
     def add_entry(self, remapping: ImportRemapping):
         path = remapping.package_id
-        if not str(path).startswith(f".cache{os.path.sep}"):
-            path = Path(".cache") / path
+        if str(self.contracts_cache) not in str(path):
+            path = self.contracts_cache / path
 
         self.import_map[remapping.key] = str(path)
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -221,9 +221,8 @@ class SolidityCompiler(CompilerAPI):
             raise IncorrectMappingFormatError()
 
         # We use these helpers to transform the values configured
-        # to values matching files in the `contracts/.cache` folder.
-        contracts_cache = base_path / ".cache"
-        builder = ImportRemappingBuilder(contracts_cache)
+        # to values matching files in the compiler cache folder.
+        builder = ImportRemappingBuilder(self.project_manager.compiler_cache_folder)
         packages_cache = self.config_manager.packages_folder
 
         # Here we hash and validate if there were changes to remappings.
@@ -233,7 +232,7 @@ class SolidityCompiler(CompilerAPI):
         if (
             self._import_remapping_hash
             and self._import_remapping_hash == hash(remappings_tuple)
-            and contracts_cache.is_dir()
+            and self.project_manager.compiler_cache_folder.is_dir()
         ):
             return self._cached_import_map
 
@@ -265,7 +264,7 @@ class SolidityCompiler(CompilerAPI):
             data_folder_cache = packages_cache / package_id
 
             # Re-build a downloaded dependency manifest into the .cache directory for imports.
-            sub_contracts_cache = contracts_cache / package_id
+            sub_contracts_cache = self.project_manager.compiler_cache_folder / package_id
             if not sub_contracts_cache.is_dir() or not list(sub_contracts_cache.iterdir()):
                 cached_manifest_file = data_folder_cache / f"{remapping_obj.name}.json"
                 if not cached_manifest_file.is_file():
@@ -435,7 +434,7 @@ class SolidityCompiler(CompilerAPI):
                 x
                 for sources in self.get_imports(list(sources), base_path=base_path).values()
                 for x in sources
-                if x.startswith(".cache")
+                if str(self.project_manager.compiler_cache_folder) in x
             )
             for parent_key in (
                 os.path.sep.join(source.split(os.path.sep)[:3]) for source in [source]

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -501,8 +501,6 @@ class SolidityCompiler(CompilerAPI):
                 arguments["base_path"] = base_path
 
             if self.project_manager.compiler_cache_folder.is_dir():
-                # TODO: equivalent of --include-path?
-                # arguments["include_path"] = self.project_manager.compiler_cache_folder
                 arguments["allow_paths"] = self.project_manager.compiler_cache_folder
 
             # Allow empty contracts, like Vyper does.
@@ -1118,19 +1116,3 @@ def _import_str_to_source_id(
 
 def _try_max(ls: List[Any]):
     return max(ls) if ls else None
-
-
-def _get_best_relative_path(path: Path, base_paths: List[Path]) -> Path:
-    """Return the first matching relative path to the given base paths"""
-    relatives = []
-
-    for base in base_paths:
-        try:
-            relatives.append(path.relative_to(base))
-        except ValueError:
-            continue
-
-    if not relatives:
-        raise ValueError(f"{path} is not a subpath of any given base paths")
-
-    return min(relatives, key=lambda x: len(x.parts))

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "py-solc-x>=2.0.2,<3",
-        "eth-ape>=0.7.0,<0.8",
+        "eth-ape>=0.7.10,<0.8",
         "ethpm-types",  # Use the version ape requires
         "eth-pydantic-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -3,7 +3,6 @@ import re
 import shutil
 from pathlib import Path
 
-import ape
 import pytest
 import solcx
 from ape import reverts

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -168,8 +168,9 @@ def test_get_imports(project, compiler):
 
 def test_get_imports_cache_folder(project, compiler):
     """Test imports when cache folder is configured"""
-    config = project.config_manager.get_config("compile")
-    config.cache_folder = project.path / ".cash"
+    compile_config = project.config_manager.get_config("compile")
+    og_cache_colder = compile_config.cache_folder
+    compile_config.cache_folder = project.path / ".cash"
     # assert False
     test_contract_paths = [
         p
@@ -195,6 +196,10 @@ def test_get_imports_cache_folder(project, compiler):
         "contracts/subfolder/Relativecontract.sol",
     }
     assert set(contract_imports) == expected
+
+    # Reset because this config is stateful across tests
+    compile_config.cache_folder = og_cache_colder
+    shutil.rmtree(og_cache_colder)
 
 
 def test_get_imports_raises_when_non_solidity_files(compiler, vyper_source_path):


### PR DESCRIPTION
### What I did

Adds support for new `cache_folder` config var which defines where to place non-project dependencies.

Example config:

```yaml
name: ape-project

compile:
  cache_folder: .cache
```

Depends on: https://github.com/ApeWorX/ape/pull/1897

### How I did it

Replaces hard references to `.cache` to configuration.  Relies on base_dir for relative paths.

### How to verify it

Run against branch from above linked PR.

### Checklist

- [x] Passes all linting checks (pre-commit and CI jobs)
- [x] New test cases have been added and are passing
- [x] Documentation has been updated
- [x] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
