### PR TITLE
chore: add python `312` black value and use `elif` in a spot

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -941,7 +941,7 @@ class SolidityCompiler(CompilerAPI):
             # Nothing to do.
             return err
 
-        if panic_cls := _get_sol_panic(err.revert_message):
+        elif panic_cls := _get_sol_panic(err.revert_message):
             return panic_cls(
                 base_err=err.base_err,
                 contract_address=err.contract_address,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ write_to = "ape_solidity/version.py"
 
 [tool.black]
 line-length = 100
-target-version = ['py38', 'py39', 'py310', 'py311']
+target-version = ['py38', 'py39', 'py310', 'py311', 'py312']
 include = '\.pyi?$'
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### What I did

use elif in a spot and add a missing python 3.12

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
