### PR TITLE
fix: put correct contract ID for compiler contract types output

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -614,17 +614,19 @@ class SolidityCompiler(CompilerAPI):
 
             vers = contract_versions[ct.name]
             settings = input_jsons[vers]["settings"]
-            if vers in compilers_used and ct.name not in (compilers_used[vers].contractTypes or []):
-                compilers_used[vers].contractTypes = [
-                    *(compilers_used[vers].contractTypes or []),
-                    ct.name,
-                ]
+            contract_id = f"{ct.source_id}:{ct.name}"
+            if vers in compilers_used and contract_id not in (
+                compilers_used[vers].contractTypes or []
+            ):
+                existing_cts = compilers_used[vers].contractTypes or []
+                if contract_id not in existing_cts:
+                    compilers_used[vers].contractTypes = [*existing_cts, contract_id]
 
             elif vers not in compilers_used:
                 compilers_used[vers] = Compiler(
                     name=self.name.lower(),
                     version=f"{vers}",
-                    contractTypes=[ct.name],
+                    contractTypes=[contract_id],
                     settings=settings,
                 )
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -344,27 +344,43 @@ def test_compiler_data_in_manifest(project):
             b >= a for a, b in zip(actual_remappings, actual_remappings[1:])
         ), "Import remappings should be sorted"
         assert f"@remapping/contracts={common_suffix}" in compiler_0426.settings["remappings"]
-        assert "UseYearn" in compiler_latest.contractTypes
+        assert "UseYearn.sol:UseYearn" in compiler_latest.contractTypes
         assert "@gnosis=.cache/gnosis/v1.3.0" in compiler_latest.settings["remappings"]
+
+        more_c = (
+            "IndirectlyImportingMoreConstrainedVersionCompanion.sol"
+            ":IndirectlyImportingMoreConstrainedVersionCompanion"
+        )
+        indirect_morec = (
+            "IndirectlyImportingMoreConstrainedVersionCompanionImport.sol"
+            ":IndirectlyImportingMoreConstrainedVersionCompanionImport"
+        )
+        indrect_morec_2 = (
+            "IndirectlyImportingMoreConstrainedVersion.sol"
+            ":IndirectlyImportingMoreConstrainedVersion"
+        )
 
         # Compiler contract types test
         assert set(compiler_0812.contractTypes) == {
-            "ImportSourceWithEqualSignVersion",
-            "ImportSourceWithNoPrefixVersion",
-            "ImportingLessConstrainedVersion",
-            "IndirectlyImportingMoreConstrainedVersion",
-            "IndirectlyImportingMoreConstrainedVersionCompanion",
-            "SpecificVersionNoPrefix",
-            "SpecificVersionRange",
-            "SpecificVersionWithEqualSign",
-            "CompilesOnce",
-            "IndirectlyImportingMoreConstrainedVersionCompanionImport",
+            "ImportSourceWithEqualSignVersion.sol:ImportSourceWithEqualSignVersion",
+            "ImportSourceWithNoPrefixVersion.sol:ImportSourceWithNoPrefixVersion",
+            "ImportingLessConstrainedVersion.sol:ImportingLessConstrainedVersion",
+            indrect_morec_2,
+            more_c,
+            "SpecificVersionNoPrefix.sol:SpecificVersionNoPrefix",
+            "SpecificVersionRange.sol:SpecificVersionRange",
+            "SpecificVersionWithEqualSign.sol:SpecificVersionWithEqualSign",
+            "CompilesOnce.sol:CompilesOnce",
+            indirect_morec,
         }
-        assert set(compiler_0612.contractTypes) == {"RangedVersion", "VagueVersion"}
+        assert set(compiler_0612.contractTypes) == {
+            "RangedVersion.sol:RangedVersion",
+            "VagueVersion.sol:VagueVersion",
+        }
         assert set(compiler_0426.contractTypes) == {
-            "ExperimentalABIEncoderV2",
-            "SpacesInPragma",
-            "ImportOlderDependency",
+            "ExperimentalABIEncoderV2.sol:ExperimentalABIEncoderV2",
+            "SpacesInPragma.sol:SpacesInPragma",
+            "ImportOlderDependency.sol:ImportOlderDependency",
         }
 
     # Ensure compiled first so that the local cached manifest exists.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,10 +14,10 @@ def runner():
 
 
 def test_compile_using_cli(ape_cli, runner):
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile", "--force"), catch_exceptions=False)
     assert result.exit_code == 0
     assert "CompilesOnce" in result.output
-    result = runner.invoke(ape_cli, ["compile"], catch_exceptions=False)
+    result = runner.invoke(ape_cli, ("compile",), catch_exceptions=False)
 
     # Already compiled so does not compile again.
     assert "CompilesOnce" not in result.output


### PR DESCRIPTION
### What I did

requires 
https://github.com/ApeWorX/ape/pull/2078
https://github.com/ApeWorX/ape/pull/2079


### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
