### PR TITLE
fix: handle missing contracts folder ID in remappings

### DIFF
--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -1183,7 +1183,7 @@ class SolidityCompiler(CompilerAPI):
 
         import_str_parts = import_str_value.split(sep)
         if base_path is None and ".cache" in import_str_parts:
-            # No base_path, do as-is. First, check if the `contracts/` folder is missing,
+            # No base_path. First, check if the `contracts/` folder is missing,
             # which is the case when compiling older Ape projects and some Foundry
             # projects as well.
             cache_index = import_str_parts.index(".cache")

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -941,8 +941,8 @@ class SolidityCompiler(CompilerAPI):
         result = {add_commit_hash(v): ls for v, ls in files_by_solc_version.items()}
 
         # Sort, so it is a nicer version map and the rest of the compilation flow
-        # is more predictable.
-        return {k: result[k] for k in sorted(result)}
+        # is more predictable. Also, remove any lingering empties.
+        return {k: result[k] for k in sorted(result) if result[k]}
 
     def _get_imported_source_paths(
         self,

--- a/tests/NonCompilingDependency/contracts/subdir/SubCompilingContract.sol
+++ b/tests/NonCompilingDependency/contracts/subdir/SubCompilingContract.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.4;
+
+contract SubCompilingContract {
+    function foo() pure public returns(bool) {
+        return true;
+    }
+}

--- a/tests/ape-config.yaml
+++ b/tests/ape-config.yaml
@@ -28,3 +28,7 @@ dependencies:
 solidity:
   # Using evm_version compatible with older and newer solidity versions.
   evm_version: constantinople
+
+  import_remapping:
+    # Legacy support test (missing contracts key in import test)
+    - "@noncompilingdependency=noncompilingdependency"

--- a/tests/contracts/Imports.sol
+++ b/tests/contracts/Imports.sol
@@ -17,11 +17,14 @@ import {
     Struct4,
     Struct5
 } from "./NumerousDefinitions.sol";
-import "@noncompilingdependency/contracts/CompilingContract.sol";
+import "@noncompilingdependency/CompilingContract.sol";
 // Purposely repeat an import to test how the plugin handles that.
-import "@noncompilingdependency/contracts/CompilingContract.sol";
+import "@noncompilingdependency/CompilingContract.sol";
 
 import "@safe/contracts/common/Enum.sol";
+
+// Purposely exclude the contracts folder to test older Ape-style project imports.
+import "@noncompilingdependency/subdir/SubCompilingContract.sol";
 
 contract Imports {
     function foo() pure public returns(bool) {

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -253,7 +253,7 @@ def test_get_version_map_dependencies(project, compiler):
             for src_id in src_ids:
                 if src_id in alt_map:
                     other_version = alt_map[src_id]
-                    versions_str = ", ".join([other_version, version])
+                    versions_str = ", ".join([str(other_version), str(version)])
                     pytest.fail(f"{src_id} in multiple version '{versions_str}'")
                 else:
                     alt_map[src_id] = version

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -248,7 +248,7 @@ def test_get_version_map_dependencies(project, compiler):
     if actual_len > expected_len:
         # Weird anomaly in CI/CD tests sometimes (at least at the time of write).
         # Including additional debug information.
-        alt_map = {}
+        alt_map: dict = {}
         for version, src_ids in actual.items():
             for src_id in src_ids:
                 if src_id in alt_map:

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -240,7 +240,29 @@ def test_get_version_map_dependencies(project, compiler):
     actual = compiler.get_version_map(paths, project=project)
 
     fail_msg = f"versions: {', '.join([str(x) for x in actual])}"
-    assert len(actual) == 2, fail_msg
+    actual_len = len(actual)
+
+    # Expecting one old version for ImportOlderDependency and one version for Yearn stuff.
+    expected_len = 2
+
+    if actual_len > expected_len:
+        # Weird anomaly in CI/CD tests sometimes (at least at the time of write).
+        # Including additional debug information.
+        alt_map = {}
+        for version, src_ids in actual.items():
+            for src_id in src_ids:
+                if src_id in alt_map:
+                    other_version = alt_map[src_id]
+                    versions_str = ", ".join([other_version, version])
+                    pytest.fail(f"{src_id} in multiple version '{versions_str}'")
+                else:
+                    alt_map[src_id] = version
+
+        # No duplicated versions found but still have unexpected extras.
+        pytest.fail(f"Unexpected number of versions. {fail_msg}")
+
+    elif actual_len < expected_len:
+        pytest.fail(fail_msg)
 
     versions = sorted(list(actual.keys()))
     older = versions[0]  # Via ImportOlderDependency

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -121,6 +121,7 @@ def test_get_imports_complex(project, compiler):
             "contracts/.cache/dependency/local/contracts/Dependency.sol",
             "contracts/.cache/dependencyofdependency/local/contracts/DependencyOfDependency.sol",
             "contracts/.cache/noncompilingdependency/local/contracts/CompilingContract.sol",
+            "contracts/.cache/noncompilingdependency/local/contracts/subdir/SubCompilingContract.sol",  # noqa: E501
             "contracts/.cache/safe/1.3.0/contracts/common/Enum.sol",
             "contracts/CompilesOnce.sol",
             "contracts/MissingPragma.sol",
@@ -355,8 +356,13 @@ def test_get_compiler_settings(project, compiler):
         "@browniedependency=contracts/.cache/browniedependency/local",
         "@dependency=contracts/.cache/dependency/local",
         "@dependencyofdependency=contracts/.cache/dependencyofdependency/local",
-        "@noncompilingdependency=contracts/.cache/noncompilingdependency/local",
+        # This remapping below was auto-corrected because imports were excluding contracts/ suffix.
+        "@noncompilingdependency=contracts/.cache/noncompilingdependency/local/contracts",
         "@safe=contracts/.cache/safe/1.3.0",
+        "browniedependency=contracts/.cache/browniedependency/local",
+        "dependency=contracts/.cache/dependency/local",
+        "dependencyofdependency=contracts/.cache/dependencyofdependency/local",
+        "safe=contracts/.cache/safe/1.3.0",
     ]
 
     # Set in config.
@@ -369,6 +375,7 @@ def test_get_compiler_settings(project, compiler):
         "contracts/.cache/dependency/local/contracts/Dependency.sol",
         "contracts/.cache/dependencyofdependency/local/contracts/DependencyOfDependency.sol",
         "contracts/.cache/noncompilingdependency/local/contracts/CompilingContract.sol",
+        "contracts/.cache/noncompilingdependency/local/contracts/subdir/SubCompilingContract.sol",
         "contracts/.cache/safe/1.3.0/contracts/common/Enum.sol",
         "contracts/CompilesOnce.sol",
         "contracts/Imports.sol",


### PR DESCRIPTION
### What I did

Helps old weird foundry projects using some git submodule nonsense pointing at changed crap, i donno... anyway, ape-solidity can be smarter and just find whatever damn dependency sources you are looking for.. may even help older ape projects work with 0.8. will see

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
