### PR TITLE
fix: resolve solidity pragma versions across imports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -63,7 +63,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.9, '3.10', '3.11', '3.12', '3.13']
+                python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
 
         env:
           GITHUB_ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -58,7 +58,6 @@ class SoliditySemVer:
 
 class SolidityVersionSpecifier:
     def __init__(self, expression: str):
-        self.pragma_str = expression
         self.expression = _normalize_pragma_expression(expression)
         self._ranges = _parse_solidity_version_expression(self.expression)
 
@@ -292,16 +291,10 @@ def add_commit_hash(version: Union[str, Version]) -> Version:
     return get_solc_version_from_binary(solc, with_commit_hash=True)
 
 
-def get_versions_can_use(
-    pragma_spec: SolidityVersionSpecifier, options: Iterable[Version]
-) -> list[Version]:
-    return sorted(list(pragma_spec.filter(options)), reverse=True)
-
-
 def select_version(
     pragma_spec: SolidityVersionSpecifier, options: Iterable[Version]
 ) -> Optional[Version]:
-    choices = get_versions_can_use(pragma_spec, options)
+    choices = sorted(pragma_spec.filter(options), reverse=True)
     return choices[0] if choices else None
 
 

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -118,7 +118,7 @@ def _parse_version_component(component: str, prefix: str | None = None) -> Versi
         for operator in (">=", "<=", "^", "~", ">", "<", "="):
             if component.startswith(operator):
                 prefix = operator
-                component = component[len(operator) :]
+                component = component.removeprefix(operator)
                 break
 
     version_parts = component.split(".")

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -1,13 +1,13 @@
 import json
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Optional, Union
 
 from ape.exceptions import CompilerError
 from packaging.version import Version
-from semantic_version import Version as SemVerVersion  # type: ignore[import-untyped]
 from solcx.install import get_executable
 from solcx.wrapper import get_solc_version as get_solc_version_from_binary
 
@@ -26,22 +26,52 @@ class Extension(Enum):
     SOL = ".sol"
 
 
+@dataclass(frozen=True)
+class SoliditySemVer:
+    major: int
+    minor: int
+    patch: int
+    prerelease: str = ""
+    build: str = ""
+
+    @classmethod
+    def parse(cls, version: str) -> "SoliditySemVer":
+        match = re.fullmatch(
+            r"(?P<major>0|[1-9]\d*)\."
+            r"(?P<minor>0|[1-9]\d*)\."
+            r"(?P<patch>0|[1-9]\d*)"
+            r"(?:-(?P<prerelease>[0-9A-Za-z.-]+))?"
+            r"(?:\+(?P<build>[0-9A-Za-z.-]+))?",
+            version,
+        )
+        if not match:
+            raise ValueError(f"Invalid Solidity version: '{version}'.")
+
+        return cls(
+            major=int(match.group("major")),
+            minor=int(match.group("minor")),
+            patch=int(match.group("patch")),
+            prerelease=match.group("prerelease") or "",
+            build=match.group("build") or "",
+        )
+
+
 class SolidityVersionSpecifier:
     def __init__(self, expression: str):
         self.pragma_str = expression
         self.expression = _normalize_pragma_expression(expression)
         self._ranges = _parse_solidity_version_expression(self.expression)
 
-    def __contains__(self, version: Union[str, Version, SemVerVersion]) -> bool:
+    def __contains__(self, version: Union[str, Version, SoliditySemVer]) -> bool:
         return self.contains(version)
 
     def __str__(self) -> str:
         return self.expression
 
     def match(self, version: Version) -> bool:
-        return self.contains(_as_npm_version(version))
+        return self.contains(_as_solidity_semver(version))
 
-    def contains(self, version: Union[str, Version, SemVerVersion]) -> bool:
+    def contains(self, version: Union[str, Version, SoliditySemVer]) -> bool:
         if isinstance(version, Version):
             return self.match(version)
 
@@ -55,7 +85,7 @@ class SolidityVersionSpecifier:
         return (version for version in versions if self.match(version))
 
 
-def _as_npm_version(version: Version) -> SemVerVersion:
+def _as_solidity_semver(version: Version) -> SoliditySemVer:
     release = ".".join(str(part) for part in (*version.release[:3], 0, 0)[:3])
     prerelease = ""
     if version.pre:
@@ -68,17 +98,17 @@ def _as_npm_version(version: Version) -> SemVerVersion:
     elif version.dev is not None:
         prerelease = f"-dev.{version.dev}"
 
-    return SemVerVersion(f"{release}{prerelease}")
+    return SoliditySemVer.parse(f"{release}{prerelease}")
 
 
-def _coerce_semver_version(version: Union[str, Version, SemVerVersion]) -> SemVerVersion:
-    if isinstance(version, SemVerVersion):
+def _coerce_semver_version(version: Union[str, Version, SoliditySemVer]) -> SoliditySemVer:
+    if isinstance(version, SoliditySemVer):
         return version
 
     if isinstance(version, Version):
-        return _as_npm_version(version)
+        return _as_solidity_semver(version)
 
-    return SemVerVersion(str(version))
+    return SoliditySemVer.parse(str(version))
 
 
 def _normalize_pragma_expression(expression: str) -> str:
@@ -137,7 +167,7 @@ def _parse_version_component(component: str, prefix: str | None = None) -> Versi
     return prefix, (numbers[0], numbers[1], numbers[2]), len(version_parts)
 
 
-def _match_solidity_component(component: VersionComponent, version: SemVerVersion) -> bool:
+def _match_solidity_component(component: VersionComponent, version: SoliditySemVer) -> bool:
     prefix, numbers, levels_present = component
     if prefix == "~":
         upper_levels = 2 if levels_present >= 2 else 1

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -7,7 +7,6 @@ from typing import Optional, Union
 
 from ape.exceptions import CompilerError
 from packaging.version import Version
-from semantic_version import NpmSpec  # type: ignore[import-untyped]
 from semantic_version import Version as SemVerVersion  # type: ignore[import-untyped]
 from solcx.install import get_executable
 from solcx.wrapper import get_solc_version as get_solc_version_from_binary
@@ -31,7 +30,7 @@ class SolidityVersionSpecifier:
     def __init__(self, expression: str):
         self.pragma_str = expression
         self.expression = _normalize_pragma_expression(expression)
-        self._npm_spec = NpmSpec(self.expression)
+        self._ranges = _parse_solidity_version_expression(self.expression)
 
     def __contains__(self, version: Union[str, Version, SemVerVersion]) -> bool:
         return self.contains(version)
@@ -40,33 +39,36 @@ class SolidityVersionSpecifier:
         return self.expression
 
     def match(self, version: Version) -> bool:
-        semver = _as_npm_version(version)
-        return self._npm_spec.match(semver) or self._matches_solc_prerelease(semver)
+        return self.contains(_as_npm_version(version))
 
     def contains(self, version: Union[str, Version, SemVerVersion]) -> bool:
         if isinstance(version, Version):
             return self.match(version)
 
         semver = _coerce_semver_version(version)
-        return self._npm_spec.match(semver) or self._matches_solc_prerelease(semver)
+        return any(
+            all(_match_solidity_component(component, semver) for component in conjunction)
+            for conjunction in self._ranges
+        )
 
     def filter(self, versions: Iterable[Version]) -> Iterable[Version]:
         return (version for version in versions if self.match(version))
 
-    def _matches_solc_prerelease(self, version: SemVerVersion) -> bool:
-        if not version.prerelease:
-            return False
-
-        if self.expression in ("*", ">=*"):
-            return True
-
-        return any(
-            _matches_partial_greater_than(block, version) for block in self.expression.split()
-        )
-
 
 def _as_npm_version(version: Version) -> SemVerVersion:
-    return SemVerVersion(version.base_version)
+    release = ".".join(str(part) for part in (*version.release[:3], 0, 0)[:3])
+    prerelease = ""
+    if version.pre:
+        prerelease_name, prerelease_number = version.pre
+        prerelease_name = {
+            "a": "alpha",
+            "b": "beta",
+        }.get(prerelease_name, prerelease_name)
+        prerelease = f"-{prerelease_name}.{prerelease_number}"
+    elif version.dev is not None:
+        prerelease = f"-dev.{version.dev}"
+
+    return SemVerVersion(f"{release}{prerelease}")
 
 
 def _coerce_semver_version(version: Union[str, Version, SemVerVersion]) -> SemVerVersion:
@@ -86,21 +88,92 @@ def _normalize_pragma_expression(expression: str) -> str:
     return re.sub(r"\s+", " ", expression)
 
 
-def _matches_partial_greater_than(block: str, version: SemVerVersion) -> bool:
-    match = re.fullmatch(r">(\d+)(?:\.(\d+))?", block)
-    if not match:
-        return False
+VersionComponent = tuple[str, tuple[int, int, int], int]
+WILDCARD_VERSION_PART = -1
 
-    major = int(match.group(1))
-    minor = int(match.group(2) or 0)
-    if match.group(2) is None:
-        lower_bound = SemVerVersion(f"{major + 1}.0.0-0")
-        upper_bound = SemVerVersion(f"{major + 1}.0.0")
-    else:
-        lower_bound = SemVerVersion(f"{major}.{minor + 1}.0-0")
-        upper_bound = SemVerVersion(f"{major}.{minor + 1}.0")
 
-    return lower_bound <= version < upper_bound
+def _parse_solidity_version_expression(expression: str) -> list[list[VersionComponent]]:
+    ranges: list[list[VersionComponent]] = []
+    for range_expression in expression.split("||"):
+        blocks = range_expression.split()
+        if not blocks:
+            raise ValueError("Empty version pragma.")
+
+        if len(blocks) == 3 and blocks[1] == "-":
+            ranges.append(
+                [
+                    _parse_version_component(blocks[0], prefix=">="),
+                    _parse_version_component(blocks[2], prefix="<="),
+                ]
+            )
+        else:
+            ranges.append([_parse_version_component(block) for block in blocks])
+
+    return ranges
+
+
+def _parse_version_component(component: str, prefix: str | None = None) -> VersionComponent:
+    if prefix is None:
+        prefix = "="
+        for operator in (">=", "<=", "^", "~", ">", "<", "="):
+            if component.startswith(operator):
+                prefix = operator
+                component = component[len(operator) :]
+                break
+
+    version_parts = component.split(".")
+    if len(version_parts) > 3:
+        raise ValueError("Too many version levels.")
+
+    numbers = [0, 0, 0]
+    for index, part in enumerate(version_parts):
+        if part in ("*", "x", "X"):
+            numbers[index] = WILDCARD_VERSION_PART
+        elif part.isdecimal():
+            numbers[index] = int(part)
+        else:
+            raise ValueError(f"Expected version number, wildcard, or operator but got '{part}'.")
+
+    return prefix, (numbers[0], numbers[1], numbers[2]), len(version_parts)
+
+
+def _match_solidity_component(component: VersionComponent, version: SemVerVersion) -> bool:
+    prefix, numbers, levels_present = component
+    if prefix == "~":
+        upper_levels = 2 if levels_present >= 2 else 1
+        return _match_solidity_component((">=", numbers, levels_present), version) and (
+            _match_solidity_component(("<=", numbers, upper_levels), version)
+        )
+
+    elif prefix == "^":
+        upper_levels = 2 if numbers[0] == 0 and levels_present != 1 else 1
+        return _match_solidity_component((">=", numbers, levels_present), version) and (
+            _match_solidity_component(("<=", numbers, upper_levels), version)
+        )
+
+    cmp = 0
+    did_compare = False
+    version_parts = (version.major, version.minor, version.patch)
+    for index in range(levels_present):
+        if cmp == 0 and numbers[index] != WILDCARD_VERSION_PART:
+            did_compare = True
+            cmp = version_parts[index] - numbers[index]
+
+    if cmp == 0 and version.prerelease and did_compare:
+        cmp = -1
+
+    if prefix == "=":
+        return cmp == 0
+    elif prefix == "<":
+        return cmp < 0
+    elif prefix == "<=":
+        return cmp <= 0
+    elif prefix == ">":
+        return cmp > 0
+    elif prefix == ">=":
+        return cmp >= 0
+
+    raise ValueError(f"Unexpected version operator: '{prefix}'.")
 
 
 def get_import_lines(source_paths: Iterable[Path]) -> dict[Path, list[str]]:

--- a/ape_solidity/_utils.py
+++ b/ape_solidity/_utils.py
@@ -3,17 +3,14 @@ import re
 from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, Union
 
 from ape.exceptions import CompilerError
-from ape.utils import pragma_str_to_specifier_set
 from packaging.version import Version
+from semantic_version import NpmSpec  # type: ignore[import-untyped]
+from semantic_version import Version as SemVerVersion  # type: ignore[import-untyped]
 from solcx.install import get_executable
 from solcx.wrapper import get_solc_version as get_solc_version_from_binary
-
-if TYPE_CHECKING:
-    from packaging.specifiers import SpecifierSet
-
 
 OUTPUT_SELECTION = [
     "abi",
@@ -28,6 +25,82 @@ OUTPUT_SELECTION = [
 
 class Extension(Enum):
     SOL = ".sol"
+
+
+class SolidityVersionSpecifier:
+    def __init__(self, expression: str):
+        self.pragma_str = expression
+        self.expression = _normalize_pragma_expression(expression)
+        self._npm_spec = NpmSpec(self.expression)
+
+    def __contains__(self, version: Union[str, Version, SemVerVersion]) -> bool:
+        return self.contains(version)
+
+    def __str__(self) -> str:
+        return self.expression
+
+    def match(self, version: Version) -> bool:
+        semver = _as_npm_version(version)
+        return self._npm_spec.match(semver) or self._matches_solc_prerelease(semver)
+
+    def contains(self, version: Union[str, Version, SemVerVersion]) -> bool:
+        if isinstance(version, Version):
+            return self.match(version)
+
+        semver = _coerce_semver_version(version)
+        return self._npm_spec.match(semver) or self._matches_solc_prerelease(semver)
+
+    def filter(self, versions: Iterable[Version]) -> Iterable[Version]:
+        return (version for version in versions if self.match(version))
+
+    def _matches_solc_prerelease(self, version: SemVerVersion) -> bool:
+        if not version.prerelease:
+            return False
+
+        if self.expression in ("*", ">=*"):
+            return True
+
+        return any(
+            _matches_partial_greater_than(block, version) for block in self.expression.split()
+        )
+
+
+def _as_npm_version(version: Version) -> SemVerVersion:
+    return SemVerVersion(version.base_version)
+
+
+def _coerce_semver_version(version: Union[str, Version, SemVerVersion]) -> SemVerVersion:
+    if isinstance(version, SemVerVersion):
+        return version
+
+    if isinstance(version, Version):
+        return _as_npm_version(version)
+
+    return SemVerVersion(str(version))
+
+
+def _normalize_pragma_expression(expression: str) -> str:
+    expression = expression.strip().replace('"', "").replace("'", "")
+    expression = re.sub(r"([<>=~^]=?)\s+", r"\1", expression)
+    expression = re.sub(r"(?<=[0-9xX*])(?=[<>=~^])", " ", expression)
+    return re.sub(r"\s+", " ", expression)
+
+
+def _matches_partial_greater_than(block: str, version: SemVerVersion) -> bool:
+    match = re.fullmatch(r">(\d+)(?:\.(\d+))?", block)
+    if not match:
+        return False
+
+    major = int(match.group(1))
+    minor = int(match.group(2) or 0)
+    if match.group(2) is None:
+        lower_bound = SemVerVersion(f"{major + 1}.0.0-0")
+        upper_bound = SemVerVersion(f"{major + 1}.0.0")
+    else:
+        lower_bound = SemVerVersion(f"{major}.{minor + 1}.0-0")
+        upper_bound = SemVerVersion(f"{major}.{minor + 1}.0")
+
+    return lower_bound <= version < upper_bound
 
 
 def get_import_lines(source_paths: Iterable[Path]) -> dict[Path, list[str]]:
@@ -65,7 +138,9 @@ def get_single_import_lines(source_path: Path) -> list[str]:
     return list(import_set)
 
 
-def get_pragma_spec_from_path(source_file_path: Union[Path, str]) -> Optional["SpecifierSet"]:
+def get_pragma_spec_from_path(
+    source_file_path: Union[Path, str],
+) -> Optional[SolidityVersionSpecifier]:
     """
     Extracts pragma information from Solidity source code.
 
@@ -73,7 +148,7 @@ def get_pragma_spec_from_path(source_file_path: Union[Path, str]) -> Optional["S
         source_file_path (Union[Path, str]): Solidity source file path.
 
     Returns:
-        ``Optional[packaging.specifiers.SpecifierSet]``
+        ``Optional[SolidityVersionSpecifier]``
     """
     path = Path(source_file_path)
     if not path.is_file():
@@ -83,7 +158,9 @@ def get_pragma_spec_from_path(source_file_path: Union[Path, str]) -> Optional["S
     return get_pragma_spec_from_str(source_str)
 
 
-def get_pragma_spec_from_str(source_str: str) -> Optional["SpecifierSet"]:
+def get_pragma_spec_from_str(
+    source_str: str,
+) -> Optional[SolidityVersionSpecifier]:
     if not (
         pragma_match := next(
             re.finditer(r"(?:\n|^)\s*pragma\s*solidity\s*([^;\n]*)", source_str), None
@@ -91,7 +168,10 @@ def get_pragma_spec_from_str(source_str: str) -> Optional["SpecifierSet"]:
     ):
         return None  # Try compiling with latest
 
-    return pragma_str_to_specifier_set(pragma_match.groups()[0])
+    try:
+        return SolidityVersionSpecifier(pragma_match.groups()[0])
+    except ValueError:
+        return None
 
 
 def load_dict(data: Union[str, dict]) -> dict:
@@ -109,11 +189,15 @@ def add_commit_hash(version: Union[str, Version]) -> Version:
     return get_solc_version_from_binary(solc, with_commit_hash=True)
 
 
-def get_versions_can_use(pragma_spec: "SpecifierSet", options: Iterable[Version]) -> list[Version]:
+def get_versions_can_use(
+    pragma_spec: SolidityVersionSpecifier, options: Iterable[Version]
+) -> list[Version]:
     return sorted(list(pragma_spec.filter(options)), reverse=True)
 
 
-def select_version(pragma_spec: "SpecifierSet", options: Iterable[Version]) -> Optional[Version]:
+def select_version(
+    pragma_spec: SolidityVersionSpecifier, options: Iterable[Version]
+) -> Optional[Version]:
     choices = get_versions_can_use(pragma_spec, options)
     return choices[0] if choices else None
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -31,6 +31,7 @@ from ape_solidity._models import ImportRemappingCache, SourceTree
 from ape_solidity._utils import (
     OUTPUT_SELECTION,
     Extension,
+    SolidityVersionSpecifier,
     add_commit_hash,
     get_pragma_spec_from_path,
     get_pragma_spec_from_str,
@@ -50,7 +51,6 @@ from ape_solidity.exceptions import (
 
 if TYPE_CHECKING:
     from ape.contracts import ContractInstance
-    from packaging.specifiers import SpecifierSet
 
 
 LICENSES_PATTERN = re.compile(r"(// SPDX-License-Identifier:\s*([^\n]*)\s)")
@@ -720,69 +720,35 @@ class SolidityCompiler(CompilerAPI):
         ):
             _install_solc(latest)
 
-        # Adjust best-versions based on imports.
-        files_by_solc_version: dict[Version, set[Path]] = {}
-        for source_file_path in path_set:
-            solc_version = self._get_best_version(source_file_path, pragma_map)
+        # Select a compiler for each requested source plus the full transitive import closure
+        # that solc must compile with it.
+        files_by_solc_version: dict[Version, set[Path]] = defaultdict(set)
+        required_imports_by_solc_version: dict[Version, set[Path]] = defaultdict(set)
+        for source_file_path in paths:
             imported_source_paths = import_tree.get_imported_paths(source_file_path)
+            source_closure = {source_file_path, *imported_source_paths}
+            solc_version = self._get_best_version_for_source_set(source_closure, pragma_map, pm)
+            files_by_solc_version[solc_version].update(source_closure)
+            required_imports_by_solc_version[solc_version].update(imported_source_paths)
 
-            for imported_source_path in imported_source_paths:
-                if imported_source_path not in pragma_map:
-                    continue
+        # If a requested source also appears in a more constrained import closure, compile it in
+        # the constrained closure only. If it is imported by roots in multiple version groups,
+        # keep it in each group because solc needs it in each standard-json input.
+        versions_by_file: dict[Path, set[Version]] = defaultdict(set)
+        for solc_version, files in files_by_solc_version.items():
+            for file in files:
+                versions_by_file[file].add(solc_version)
 
-                imported_pragma_spec = pragma_map[imported_source_path]
-                imported_version = self._get_best_version(imported_source_path, pragma_map)
-
-                if imported_pragma_spec is not None and (
-                    str(imported_pragma_spec)[0].startswith("=")
-                    or str(imported_pragma_spec)[0].isdigit()
-                ):
-                    # Have to use this version.
-                    solc_version = imported_version
-                    break
-
-                elif imported_version < solc_version:
-                    # If we get here, the highest version of an import is lower than the reference.
-                    solc_version = imported_version
-
-            if solc_version not in files_by_solc_version:
-                files_by_solc_version[solc_version] = set()
-
-            for path in (source_file_path, *imported_source_paths):
-                files_by_solc_version[solc_version].add(path)
-
-        # If being used in another version AND no imports in this version require it,
-        # remove it from this version.
         cleaned_mapped: dict[Version, set[Path]] = defaultdict(set)
         for solc_version, files in files_by_solc_version.items():
-            other_versions = {v: ls for v, ls in files_by_solc_version.items() if v != solc_version}
             for file in files:
-                other_versions_used_in = {v for v in other_versions if file in other_versions[v]}
-                if not other_versions_used_in:
-                    # This file is only in 1 version, which is perfect.
-                    cleaned_mapped[solc_version].add(file)
+                if (
+                    len(versions_by_file[file]) > 1
+                    and file not in required_imports_by_solc_version[solc_version]
+                ):
                     continue
 
-                # This file is in multiple versions. Attempt to clean.
-                for other_version in other_versions_used_in:
-                    # Other files that may need this file are any file that is not this file as well
-                    # any file that is not also found the other version. We want to make sure
-                    # before removing this file that it won't be needed.
-                    other_files_that_may_need_this_file = [
-                        f for f in files if f != file and f not in other_versions[other_version]
-                    ]
-                    if other_files_that_may_need_this_file:
-                        # This file is used by other files in this version, so we must keep it.
-                        cleaned_mapped[solc_version].add(file)
-                        continue
-
-                    # Remove other the rest of files.
-                    other_files_can_remove = [
-                        f for f in files if f != file and f in other_versions[other_version]
-                    ]
-                    for other_file in other_files_can_remove:
-                        if other_file in cleaned_mapped[solc_version]:
-                            cleaned_mapped[solc_version].remove(other_file)
+                cleaned_mapped[solc_version].add(file)
 
         result = {add_commit_hash(v): ls for v, ls in cleaned_mapped.items()}
 
@@ -790,7 +756,67 @@ class SolidityCompiler(CompilerAPI):
         # is more predictable. Also, remove any lingering empties.
         return {k: result[k] for k in sorted(result) if result[k]}
 
-    def _get_pramga_spec_from_str(self, source_str: str) -> Optional["SpecifierSet"]:
+    def _get_best_version_for_source_set(
+        self,
+        source_paths: set[Path],
+        source_by_pragma_spec: dict[Path, Optional[SolidityVersionSpecifier]],
+        project: ProjectManager,
+    ) -> Version:
+        pragma_map = {
+            path: pragma_spec
+            for path in sorted(source_paths)
+            if (pragma_spec := source_by_pragma_spec.get(path))
+        }
+        if not pragma_map:
+            return self._get_best_version_without_pragma()
+
+        if selected := self._select_version_for_pragmas(
+            pragma_map.values(), self.installed_versions
+        ):
+            return add_commit_hash(selected)
+
+        if selected := self._select_version_for_pragmas(
+            pragma_map.values(), self.available_versions
+        ):
+            _install_solc(selected)
+            return add_commit_hash(selected)
+
+        source_ids = ", ".join(
+            f"{get_relative_path(path, project.path)} ({pragma_spec})"
+            for path, pragma_spec in pragma_map.items()
+        )
+        raise CompilerError(
+            "No installed or available Solidity compiler version satisfies "
+            f"the combined pragma constraints: {source_ids}."
+        )
+
+    def _select_version_for_pragmas(
+        self,
+        pragma_specs: Iterable[SolidityVersionSpecifier],
+        options: Iterable[Version],
+    ) -> Optional[Version]:
+        candidates = list(options)
+        for pragma_spec in pragma_specs:
+            candidates = get_versions_can_use(pragma_spec, candidates)
+            if not candidates:
+                return None
+
+        return candidates[0] if candidates else None
+
+    def _get_best_version_without_pragma(self) -> Version:
+        if latest_installed := self.latest_installed_version:
+            compiler_version = latest_installed
+
+        elif latest := self.latest_version:
+            _install_solc(latest)
+            compiler_version = latest
+
+        else:
+            raise SolcInstallError()
+
+        return add_commit_hash(compiler_version)
+
+    def _get_pramga_spec_from_str(self, source_str: str) -> Optional[SolidityVersionSpecifier]:
         if not (pragma_spec := get_pragma_spec_from_str(source_str)):
             return None
 

--- a/ape_solidity/compiler.py
+++ b/ape_solidity/compiler.py
@@ -35,7 +35,6 @@ from ape_solidity._utils import (
     add_commit_hash,
     get_pragma_spec_from_path,
     get_pragma_spec_from_str,
-    get_versions_can_use,
     load_dict,
     select_version,
     strip_commit_hash,
@@ -607,7 +606,7 @@ class SolidityCompiler(CompilerAPI):
         if settings_version := self._get_configured_version(project=pm):
             version = settings_version
 
-        elif pragma := self._get_pramga_spec_from_str(code):
+        elif pragma := self._get_pragma_spec_from_str(code):
             if selected_version := select_version(pragma, self.installed_versions):
                 version = selected_version
             else:
@@ -785,9 +784,12 @@ class SolidityCompiler(CompilerAPI):
             f"{get_relative_path(path, project.path)} ({pragma_spec})"
             for path, pragma_spec in pragma_map.items()
         )
+        installed_versions = _format_versions(self.installed_versions)
+        available_versions = _format_versions(self.available_versions)
         raise CompilerError(
             "No installed or available Solidity compiler version satisfies "
-            f"the combined pragma constraints: {source_ids}."
+            f"the combined pragma constraints: {source_ids}. "
+            f"Installed versions: {installed_versions}. Available versions: {available_versions}."
         )
 
     def _select_version_for_pragmas(
@@ -797,11 +799,11 @@ class SolidityCompiler(CompilerAPI):
     ) -> Optional[Version]:
         candidates = list(options)
         for pragma_spec in pragma_specs:
-            candidates = get_versions_can_use(pragma_spec, candidates)
+            candidates = list(pragma_spec.filter(candidates))
             if not candidates:
                 return None
 
-        return candidates[0] if candidates else None
+        return sorted(candidates, reverse=True)[0]
 
     def _get_best_version_without_pragma(self) -> Version:
         if latest_installed := self.latest_installed_version:
@@ -816,7 +818,7 @@ class SolidityCompiler(CompilerAPI):
 
         return add_commit_hash(compiler_version)
 
-    def _get_pramga_spec_from_str(self, source_str: str) -> Optional[SolidityVersionSpecifier]:
+    def _get_pragma_spec_from_str(self, source_str: str) -> Optional[SolidityVersionSpecifier]:
         if not (pragma_spec := get_pragma_spec_from_str(source_str)):
             return None
 
@@ -845,45 +847,6 @@ class SolidityCompiler(CompilerAPI):
             raise CompilerError(f"Solidity version specification '{pragma_spec}' could not be met.")
 
         return pragma_spec
-
-    def _get_best_versions(self, path: Path, options, source_by_pragma_spec: dict) -> list[Version]:
-        # NOTE: Doesn't install.
-        if pragma_spec := source_by_pragma_spec.get(path):
-            res = get_versions_can_use(pragma_spec, list(options))
-        elif latest_installed := self.latest_installed_version:
-            res = [latest_installed]
-        elif latest := self.latest_version:
-            res = [latest]
-        else:
-            raise SolcInstallError()
-
-        return [add_commit_hash(v) for v in res]
-
-    def _get_best_version(self, path: Path, source_by_pragma_spec: dict) -> Version:
-        compiler_version: Optional[Version] = None
-        if pragma_spec := source_by_pragma_spec.get(path):
-            if selected := select_version(pragma_spec, self.installed_versions):
-                compiler_version = selected
-
-            elif selected := select_version(pragma_spec, self.available_versions):
-                # Install missing version.
-                # NOTE: Must be installed before adding commit hash.
-                _install_solc(selected)
-                compiler_version = add_commit_hash(selected)
-
-        elif latest_installed := self.latest_installed_version:
-            compiler_version = latest_installed
-
-        elif latest := self.latest_version:
-            # Download latest version.
-            _install_solc(latest)
-            compiler_version = latest
-
-        else:
-            raise SolcInstallError()
-
-        assert compiler_version  # For mypy
-        return add_commit_hash(compiler_version)
 
     def enrich_error(self, err: ContractLogicError) -> ContractLogicError:
         if not is_0x_prefixed(err.revert_message):
@@ -1219,6 +1182,11 @@ def _get_sol_panic(revert_message: str) -> Optional[type[RuntimeErrorUnion]]:
 
 def _try_max(ls: list[Any]):
     return max(ls) if ls else None
+
+
+def _format_versions(versions: Iterable[Version]) -> str:
+    sorted_versions = sorted(versions, reverse=True)
+    return ", ".join(str(version) for version in sorted_versions) or "none"
 
 
 def _validate_can_compile(paths: Iterable[Path]) -> Sequence[Path]:

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,6 @@ setup(
         "eth-pydantic-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",
-        "semantic-version>=2.10,<3",
     ],
     python_requires=">=3.10,<4",
     extras_require=extras_require,

--- a/setup.py
+++ b/setup.py
@@ -75,8 +75,9 @@ setup(
         "eth-pydantic-types",  # Use the version ape requires
         "packaging",  # Use the version ape requires
         "requests",
+        "semantic-version>=2.10,<3",
     ],
-    python_requires=">=3.9,<4",
+    python_requires=">=3.10,<4",
     extras_require=extras_require,
     py_modules=["ape_solidity"],
     entry_points={
@@ -97,10 +98,10 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
     ],
 )

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest import mock
 
 import pytest
 import solcx
@@ -8,10 +9,159 @@ from ape.utils import get_full_extension
 from ethpm_types import ContractType
 from packaging.version import Version
 
+from ape_solidity._utils import add_commit_hash, get_pragma_spec_from_str
 from ape_solidity.exceptions import IndexOutOfBoundsError
 
 EXPECTED_NON_SOLIDITY_ERR_MSG = "Unable to compile 'RandomVyperFile.vy' using Solidity compiler."
 raises_because_not_sol = pytest.raises(CompilerError, match=EXPECTED_NON_SOLIDITY_ERR_MSG)
+
+SOLC_SEMVER_POSITIVE_CASES = (
+    ("*", "1.2.3-foo"),
+    ("1.0.0 - 2.0.0", "1.2.3"),
+    ("1.0.0", "1.0.0"),
+    ("1.0", "1.0.0"),
+    ("1", "1.0.0"),
+    (">=*", "0.2.4"),
+    ("*", "1.2.3"),
+    (">=1.0.0", "1.0.0"),
+    (">=1.0.0", "1.0.1"),
+    (">=1.0.0", "1.1.0"),
+    (">1.0.0", "1.0.1"),
+    (">1.0.0", "1.1.0"),
+    ("<=2.0.0", "2.0.0"),
+    ("<=2.0.0", "1.9999.9999"),
+    ("<=2.0.0", "0.2.9"),
+    ("<2.0.0", "1.9999.9999"),
+    ("<2.0.0", "0.2.9"),
+    ("<1.0", "1.0.0-pre"),
+    ("<1", "1.0.0-pre"),
+    (">= 1.0.0", "1.0.0"),
+    (">=  1.0.0", "1.0.1"),
+    (">=   1.0.0", "1.1.0"),
+    ("> 1.0.0", "1.0.1"),
+    (">  1.0.0", "1.1.0"),
+    ("<=   2.0.0", "2.0.0"),
+    ("<= 2.0.0", "1.9999.9999"),
+    ("<=  2.0.0", "0.2.9"),
+    ("<    2.0.0", "1.9999.9999"),
+    ("<\t2.0.0", "0.2.9"),
+    (">=0.1.97", "0.1.97"),
+    ("0.1.20 || 1.2.4", "1.2.4"),
+    (">=0.2.3 || <0.0.1", "0.0.0"),
+    (">=0.2.3 || <0.0.1", "0.2.3"),
+    (">=0.2.3 || <0.0.1", "0.2.4"),
+    ('"2.x.x"', "2.1.3"),
+    ("1.2.x", "1.2.3"),
+    ('"1.2.x" || "2.x"', "2.1.3"),
+    ('"1.2.x" || "2.x"', "1.2.3"),
+    ("x", "1.2.3"),
+    ("2.*.*", "2.1.3"),
+    ("1.2.*", "1.2.3"),
+    ("1.2.* || 2.*", "2.1.3"),
+    ("1.2.* || 2.*", "1.2.3"),
+    ("*", "1.2.3"),
+    ("2", "2.1.2"),
+    ("2.3", "2.3.1"),
+    ("~2.4", "2.4.0"),
+    ("~2.4", "2.4.5"),
+    ("~1", "1.2.3"),
+    ("~1.0", "1.0.2"),
+    ("~ 1.0", "1.0.2"),
+    ("~ 1.0.3", "1.0.12"),
+    (">=1", "1.0.0"),
+    (">= 1", "1.0.0"),
+    ("<1.2", "1.1.1"),
+    ("< 1.2", "1.1.1"),
+    ("=0.7.x", "0.7.2"),
+    ("<=0.7.x", "0.7.2"),
+    (">=0.7.x", "0.7.2"),
+    ("<=0.7.x", "0.6.2"),
+    ("~1.2.1 >=1.2.3", "1.2.3"),
+    ("~1.2.1 =1.2.3", "1.2.3"),
+    ("~1.2.1 1.2.3", "1.2.3"),
+    ("~1.2.1 >=1.2.3 1.2.3", "1.2.3"),
+    ("~1.2.1 1.2.3 >=1.2.3", "1.2.3"),
+    ('>="1.2.1" 1.2.3', "1.2.3"),
+    ("1.2.3 >=1.2.1", "1.2.3"),
+    (">=1.2.3 >=1.2.1", "1.2.3"),
+    (">=1.2.1 >=1.2.3", "1.2.3"),
+    (">=1.2", "1.2.8"),
+    ("^1.2.3", "1.8.1"),
+    ("^0.1.2", "0.1.2"),
+    ("^0.1", "0.1.2"),
+    ("^1.2", "1.4.2"),
+    ("^1.2", "1.2.0"),
+    ("^1", "1.2.0"),
+    ("<=1.2.3", "1.2.3-beta"),
+    (">1.2", "1.3.0-beta"),
+    ("<1.2.3", "1.2.3-beta"),
+    ("^1.2 ^1", "1.4.2"),
+    ("^0", "0.5.1"),
+    ("^0", "0.1.1"),
+)
+
+SOLC_SEMVER_NEGATIVE_CASES = (
+    ("^0^1", "0.0.0"),
+    ("^0^1", "1.0.0"),
+    ("1.0.0 - 2.0.0", "2.2.3"),
+    ("1.0", "1.0.0-pre"),
+    ("1", "1.0.0-pre"),
+    ("^1.2.3", "1.2.3-pre"),
+    ("^1.2", "1.2.0-pre"),
+    ("^1.2", "1.2.1-pre"),
+    ("^1.2.3", "1.2.3-beta"),
+    ("=0.7.x", "0.7.0-asdf"),
+    (">=0.7.x", "0.7.0-asdf"),
+    ("1.0.0", "1.0.1"),
+    (">=1.0.0", "0.0.0"),
+    (">=1.0.0", "0.0.1"),
+    (">=1.0.0", "0.1.0"),
+    (">1.0.0", "0.0.1"),
+    (">1.0.0", "0.1.0"),
+    ("<=2.0.0", "3.0.0"),
+    ("<=2.0.0", "2.9999.9999"),
+    ("<=2.0.0", "2.2.9"),
+    ("<2.0.0", "2.9999.9999"),
+    ("<2.0.0", "2.2.9"),
+    (">=0.1.97", "0.1.93"),
+    ("0.1.20 || 1.2.4", "1.2.3"),
+    (">=0.2.3 || <0.0.1", "0.0.3"),
+    (">=0.2.3 || <0.0.1", "0.2.2"),
+    ('"2.x.x"', "1.1.3"),
+    ('"2.x.x"', "3.1.3"),
+    ("1.2.x", "1.3.3"),
+    ('"1.2.x" || "2.x"', "3.1.3"),
+    ('"1.2.x" || "2.x"', "1.1.3"),
+    ("2.*.*", "1.1.3"),
+    ("2.*.*", "3.1.3"),
+    ("1.2.*", "1.3.3"),
+    ("1.2.* || 2.*", "3.1.3"),
+    ("1.2.* || 2.*", "1.1.3"),
+    ("2", "1.1.2"),
+    ("2.3", "2.4.1"),
+    ("~2.4", "2.5.0"),
+    ("~2.4", "2.3.9"),
+    ("~1", "0.2.3"),
+    ("~1.0", "1.1.0"),
+    ("<1", "1.0.0"),
+    (">=1.2", "1.1.1"),
+    ("=0.7.x", "0.8.2"),
+    (">=0.7.x", "0.6.2"),
+    ("<0.7.x", "0.7.2"),
+    ("=1.2.3", "1.2.3-beta"),
+    (">1.2", "1.2.8"),
+    ("^1.2.3", "2.0.0-alpha"),
+    ("^0.6", "0.6.2-alpha"),
+    ("^0.6", "0.6.0-alpha"),
+    ("^1.2", "1.2.1-pre"),
+    ("^1.2.3", "1.2.2"),
+    ("^1", "1.2.0-pre"),
+    ("^1", "1.2.0-pre"),
+    ("^1.2", "1.1.9"),
+    ("^0", "0.5.1-pre"),
+    ("^0", "0.0.0-pre"),
+    ("^0", "1.0.0"),
+)
 
 
 def test_get_config(project, compiler):
@@ -188,6 +338,47 @@ def test_get_imports_full_project(project, compiler):
             assert source_id in actual, f"{source_id}'s imports not present."
 
 
+@pytest.mark.parametrize(
+    ("pragma", "matching_version"),
+    (
+        (">= 0.4.19 < 0.7.0", "0.6.12"),
+        (">=0.8.0 <0.9.0", "0.8.28"),
+        ("^0.8.20 || ^0.9.0", "0.9.0"),
+        ("=0.8.12", "0.8.12"),
+        ("0.8.12", "0.8.12"),
+    ),
+)
+def test_get_pragma_spec_supports_solc_style_ranges(pragma, matching_version):
+    spec = get_pragma_spec_from_str(f"pragma solidity {pragma};")
+    assert spec is not None
+    assert Version(matching_version) in spec
+
+
+@pytest.mark.parametrize(("pragma", "matching_version"), SOLC_SEMVER_POSITIVE_CASES)
+def test_get_pragma_spec_matches_solc_semver_positive_examples(pragma, matching_version):
+    spec = get_pragma_spec_from_str(f"pragma solidity {pragma};")
+    assert spec is not None
+    assert matching_version in spec
+
+
+@pytest.mark.parametrize(("pragma", "non_matching_version"), SOLC_SEMVER_NEGATIVE_CASES)
+def test_get_pragma_spec_matches_solc_semver_negative_examples(pragma, non_matching_version):
+    spec = get_pragma_spec_from_str(f"pragma solidity {pragma};")
+    assert spec is not None
+    assert non_matching_version not in spec
+
+
+def create_solidity_project(tmp_path, sources):
+    project_path = tmp_path / "SolidityProject"
+    contracts_path = project_path / "contracts"
+    contracts_path.mkdir(parents=True)
+    (project_path / "ape-config.yaml").write_text("name: SolidityProject\n", encoding="utf8")
+    for name, source in sources.items():
+        (contracts_path / name).write_text(source, encoding="utf8")
+
+    return Project(project_path)
+
+
 def test_get_version_map(project, compiler):
     """
     Test that a strict version pragma is recognized in the version map.
@@ -214,6 +405,109 @@ def test_get_version_map_importing_more_constrained_version(project, compiler):
     actual = compiler.get_version_map((path,), project=project)
     expected_version = Version("0.8.12+commit.f00d7308")
     expected_sources = ("ImportSourceWithEqualSignVersion", "SpecificVersionWithEqualSign")
+    assert expected_version in actual
+
+    actual_ids = [x.stem for x in actual[expected_version]]
+    assert all(e in actual_ids for e in expected_sources)
+
+
+def test_get_version_map_imported_source_has_stricter_upper_bound(tmp_path, compiler):
+    project = create_solidity_project(
+        tmp_path,
+        {
+            "ImportSourceWithUpperBound.sol": """// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0 <0.9.0;
+
+import "./UpperBoundImport.sol";
+
+contract ImportSourceWithUpperBound is UpperBoundImport {}
+""",
+            "UpperBoundImport.sol": """// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0 <0.8.13;
+
+contract UpperBoundImport {}
+""",
+        },
+    )
+    path = project.sources.lookup("contracts/ImportSourceWithUpperBound.sol")
+
+    actual = compiler.get_version_map((path,), project=project)
+    expected_version = Version("0.8.12+commit.f00d7308")
+    expected_sources = ("ImportSourceWithUpperBound", "UpperBoundImport")
+    assert expected_version in actual
+
+    actual_ids = [x.stem for x in actual[expected_version]]
+    assert all(e in actual_ids for e in expected_sources)
+
+
+def test_get_version_map_raises_for_incompatible_import_constraints(compiler, mocker, tmp_path):
+    mocker.patch.object(
+        type(compiler),
+        "installed_versions",
+        new_callable=mock.PropertyMock,
+        return_value=[Version("0.8.28"), Version("0.7.6")],
+    )
+    mocker.patch.object(
+        type(compiler),
+        "available_versions",
+        new_callable=mock.PropertyMock,
+        return_value=[Version("0.8.28"), Version("0.7.6")],
+    )
+    project = create_solidity_project(
+        tmp_path,
+        {
+            "IncompatibleImport.sol": """// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+import "./IncompatibleImportDependency.sol";
+
+contract IncompatibleImport is IncompatibleImportDependency {}
+""",
+            "IncompatibleImportDependency.sol": """// SPDX-License-Identifier: MIT
+
+pragma solidity <0.8.0;
+
+contract IncompatibleImportDependency {}
+""",
+        },
+    )
+    path = project.sources.lookup("contracts/IncompatibleImport.sol")
+
+    with pytest.raises(CompilerError) as err:
+        compiler.get_version_map((path,), project=project)
+
+    message = str(err.value)
+    assert "combined pragma constraints" in message
+    assert "contracts/IncompatibleImport.sol" in message
+    assert "contracts/IncompatibleImportDependency.sol" in message
+
+
+def test_get_version_map_no_pragma_importer_uses_import_constraints(tmp_path, compiler):
+    project = create_solidity_project(
+        tmp_path,
+        {
+            "MissingPragmaImportsStrict.sol": """// SPDX-License-Identifier: MIT
+
+import "./SpecificVersionWithEqualSign.sol";
+
+contract MissingPragmaImportsStrict is SpecificVersionWithEqualSign {}
+""",
+            "SpecificVersionWithEqualSign.sol": """// SPDX-License-Identifier: MIT
+
+pragma solidity =0.8.12;
+
+contract SpecificVersionWithEqualSign {}
+""",
+        },
+    )
+    path = project.sources.lookup("contracts/MissingPragmaImportsStrict.sol")
+
+    actual = compiler.get_version_map((path,), project=project)
+    expected_version = Version("0.8.12+commit.f00d7308")
+    expected_sources = ("MissingPragmaImportsStrict", "SpecificVersionWithEqualSign")
     assert expected_version in actual
 
     actual_ids = [x.stem for x in actual[expected_version]]
@@ -655,7 +949,7 @@ def test_compile_outputs_compiler_data_to_manifest(project, compiler):
     actual = project.manifest.compilers[0]
     assert actual.name == "solidity"
     assert "CompilesOnce" in actual.contractTypes
-    assert actual.version == "0.8.28+commit.7893614a"
+    assert actual.version == f"{add_commit_hash(compiler.latest_installed_version)}"
     # Compiling again should not add the same compiler again.
     _ = [c for c in compiler.compile((path,), project=project)]
     length_again = len(project.manifest.compilers or [])

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -368,6 +368,34 @@ def test_get_pragma_spec_matches_solc_semver_negative_examples(pragma, non_match
     assert non_matching_version not in spec
 
 
+@pytest.mark.parametrize(
+    ("pragma", "matching_version"),
+    (
+        ("<=1.2.3", "1.2.3b0"),
+        ("<1.2.3", "1.2.3b0"),
+        (">1.2", "1.3.0b0"),
+    ),
+)
+def test_get_pragma_spec_matches_packaging_version_prereleases(pragma, matching_version):
+    spec = get_pragma_spec_from_str(f"pragma solidity {pragma};")
+    assert spec is not None
+    assert Version(matching_version) in spec
+
+
+@pytest.mark.parametrize(
+    ("pragma", "non_matching_version"),
+    (
+        ("=1.2.3", "1.2.3b0"),
+        ("^1.2.3", "1.2.3b0"),
+        ("^0.6", "0.6.2a0"),
+    ),
+)
+def test_get_pragma_spec_rejects_packaging_version_prereleases(pragma, non_matching_version):
+    spec = get_pragma_spec_from_str(f"pragma solidity {pragma};")
+    assert spec is not None
+    assert Version(non_matching_version) not in spec
+
+
 def create_solidity_project(tmp_path, sources):
     project_path = tmp_path / "SolidityProject"
     contracts_path = project_path / "contracts"
@@ -483,6 +511,8 @@ contract IncompatibleImportDependency {}
     assert "combined pragma constraints" in message
     assert "contracts/IncompatibleImport.sol" in message
     assert "contracts/IncompatibleImportDependency.sol" in message
+    assert "Installed versions: 0.8.28, 0.7.6" in message
+    assert "Available versions: 0.8.28, 0.7.6" in message
 
 
 def test_get_version_map_no_pragma_importer_uses_import_constraints(tmp_path, compiler):


### PR DESCRIPTION
## Motivation
Solidity validates version pragmas across every source compiled in a single solc invocation, including imported files. Ape installs or selects the compiler before invoking solc, so choosing from only the requested root source can pick a compiler version that an imported source rejects.

Ape also needs to understand Solidity pragma expressions before it can safely preselect a compiler. The previous parser handled simple constraints, but did not cover the full Solidity semver matcher behavior used by solc, including hyphen ranges, wildcards, tilde/caret ranges, quoted ranges, OR alternatives, adjacent constraints, and Solidity's prerelease comparison rules.

## Summary
- Select Solidity compiler versions from each requested source plus its transitive import closure.
- Keep imported sources in each standard-json input where solc needs them, while avoiding duplicate root-source compilation when a more constrained closure owns that source.
- Replace the previous pragma parsing path with `SolidityVersionSpecifier`, which mirrors Solidity's semver matcher instead of delegating range matching to Python PEP 440 specifiers or npm range semantics.
- Continue using `packaging.version.Version` as Ape's compiler-version type for stable py-solc-x compiler versions, while preserving exact Solidity semver parsing for pragma candidates with a tiny local `SoliditySemVer` value.
- Preserve Solidity-specific prerelease behavior, including cases where prerelease builds satisfy `<`, `<=`, wildcard, hyphen, and partial-version constraints differently from npm range semantics.
- Avoid adding `semantic-version` as a direct dependency; Solidity semver parsing and matching are local to this plugin.
- Remove dead best-version helpers and avoid repeated candidate sorting while combining pragma constraints.
- Include installed and available compiler versions in incompatible-pragma errors.
- Align package metadata and CI with Ape's Python `>=3.10,<4` support range, including Python 3.14.

## Why Not `packaging` Or `NpmSpec`
Solidity pragmas are semver match expressions, not PEP 440 specifiers. `packaging.version.Version` is still appropriate for Ape's stable compiler-version flow, but it cannot faithfully represent every solc semver string. Some published solc versions are normalized into different PEP 440 spellings, and nightly-style prereleases can be invalid PEP 440 entirely.

Solidity pragmas also look npm-like, but solc's matcher is not equivalent to `semantic_version.NpmSpec`. In Solidity's `SemVerHandler`, candidate prerelease versions compare as lower than the release when the compared numeric levels tie. That accepts cases such as:

```text
<=1.2.3              matches 1.2.3-beta
<1.2.3               matches 1.2.3-beta
>1.2                 matches 1.3.0-beta
0.8.30 - 0.8.31      matches 0.8.31-pre.1+commit.e4323a63
*                    matches prerelease/nightly builds
```

`NpmSpec` rejects some of these, and forcing always-on prerelease matching creates false positives for Solidity caret ranges, such as accepting prereleases that solc rejects. This PR therefore owns both the small Solidity semver value parser and the Solidity-specific range matcher locally.

## References
- [solc Parser pragma handling](https://github.com/argotorg/solidity/blob/6fd1c6ca619c70ee715a535615887ff5906c1170/libsolidity/parsing/Parser.cpp#L191-L269): `parsePragmaVersion()` checks the current compiler version and `parsePragmaDirective()` feeds Solidity pragma tokens into that check.
- [solc semver expression parser](https://github.com/argotorg/solidity/blob/6fd1c6ca619c70ee715a535615887ff5906c1170/liblangutil/SemVerHandler.cpp#L161-L222): parses pragma expressions as semver match expressions, including adjacent constraints and alternatives.
- [solc semver matching logic](https://github.com/argotorg/solidity/blob/6fd1c6ca619c70ee715a535615887ff5906c1170/liblangutil/SemVerHandler.cpp#L81-L128): implements tilde/caret handling and prerelease comparison behavior.
- [solc semver matcher tests](https://github.com/argotorg/solidity/blob/6fd1c6ca619c70ee715a535615887ff5906c1170/test/libsolidity/SemVerMatcher.cpp#L99-L270): source for the positive/negative semver examples ported here.

## Validation
- `uv run black --check ape_solidity/_utils.py`
- `uv run isort --check-only ape_solidity/_utils.py`
- `uv run flake8 ape_solidity/_utils.py`
- `uv run mypy .`
- `uv run pytest tests/test_compiler.py -k 'pragma_spec or get_version_map'` (`164 passed` on Python 3.12.12)
- solc-bin manifest smoke check: parsed 2,017 unique published `longVersion` strings, generated 1,237 pragma expressions, and ran 2,495,029 matcher comparisons without parser errors.

Note: a full local `tests/test_compiler.py` run was previously blocked by the existing local dependency fixture/remapping setup for Safe contracts, but the live PR checks have been passing.
